### PR TITLE
feat: allow 'boolean' and 'number[]' in filters

### DIFF
--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -1,4 +1,5 @@
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
+import { qs } from './qs';
 
 class TestRailException extends Error {
   constructor(message: string) {
@@ -483,18 +484,12 @@ function base64(string: string) {
   }
 }
 
-function qs(object?: any): string {
-  return object ? '&' + new URLSearchParams(object) : '';
-}
-
 function sleep(timeout: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
 declare namespace TestRail {
-  interface UnknownObject {
-    [key: string]: unknown;
-  }
+  type UnknownObject = Record<string, unknown>;
 
   namespace Payload {
     type AddAttachment =
@@ -634,7 +629,7 @@ declare namespace TestRail {
     interface AddProject extends UnknownObject {
       name?: string;
       announcement?: string;
-      show_announcement?: string;
+      show_announcement?: boolean;
       suite_mode?: number;
     }
 
@@ -700,67 +695,67 @@ declare namespace TestRail {
       suite_id?: number;
       created_after?: number;
       created_before?: number;
-      created_by?: string;
+      created_by?: number | number[];
       filter?: string;
       limit?: number;
-      milestone_id?: string;
+      milestone_id?: number | number[];
       offset?: number;
-      priority_id?: string;
+      priority_id?: number | number[];
       refs?: string;
       section_id?: number;
-      template_id?: string;
-      type_id?: string;
+      template_id?: number | number[];
+      type_id?: number | number[];
       updated_after?: number;
       updated_before?: number;
-      updated_by?: string;
+      updated_by?: number | number[];
     }
 
     interface MilestoneFilters extends UnknownObject {
-      is_completed?: number;
-      is_started?: number;
+      is_completed?: boolean;
+      is_started?: boolean;
     }
 
     interface PlanFilters extends UnknownObject {
       created_after?: number;
       created_before?: number;
-      created_by?: string;
-      is_completed?: number;
+      created_by?: number | number[];
+      is_completed?: boolean;
       limit?: number;
       offset?: number;
-      milestone_id?: string;
+      milestone_id?: number | number[];
     }
 
     interface ProjectFilters extends UnknownObject {
-      is_completed?: number;
+      is_completed?: boolean;
     }
 
     interface ResultFilters extends UnknownObject {
       defects?: string;
       limit?: number;
       offset?: number;
-      status_id?: string;
+      status_id?: number | number[];
     }
 
     interface ResultForRunFilters extends UnknownObject {
       created_after?: number;
       created_before?: number;
-      created_by?: string;
+      created_by?: number | number[];
       defects?: string;
       limit?: number;
       offset?: number;
-      status_id?: string;
+      status_id?: number | number[];
     }
 
     interface RunFilters extends UnknownObject {
       created_after?: number;
       created_before?: number;
-      created_by?: string;
-      is_completed?: number;
+      created_by?: number | number[];
+      is_completed?: boolean;
       limit?: number;
       offset?: number;
-      milestone_id?: string;
+      milestone_id?: number | number[];
       refs?: string;
-      suite_id?: string;
+      suite_id?: number | number[];
     }
 
     interface SectionFilters extends UnknownObject {
@@ -768,7 +763,7 @@ declare namespace TestRail {
     }
 
     interface TestFilters extends UnknownObject {
-      status_id?: string;
+      status_id?: number | number[];
     }
 
     interface UserFilters extends UnknownObject {
@@ -846,7 +841,7 @@ declare namespace TestRail {
     }
 
     interface Change extends UnknownObject {
-      field: String;
+      field: string;
       label?: string;
       new_text?: string;
       new_value?: string | number | number[];

--- a/src/qs.ts
+++ b/src/qs.ts
@@ -1,0 +1,25 @@
+export function qs(object?: Record<string, any>): string {
+  if (!object) {
+    return '';
+  }
+
+  let qs = '';
+
+  for (const [key, value] of Object.entries(object)) {
+    let newValue = value;
+
+    if (typeof value === 'boolean') {
+      newValue = +value;
+    } else if (Array.isArray(value)) {
+      newValue = value.join(',');
+    }
+
+    if (qs !== '') {
+      qs += '&';
+    }
+
+    qs += `&${key}=${encodeURIComponent(newValue)}`;
+  }
+
+  return qs;
+}

--- a/test/_helper.ts
+++ b/test/_helper.ts
@@ -3,8 +3,9 @@ import chaiAsPromised from 'chai-as-promised';
 import fs from 'fs';
 import { mock as tsMock } from 'intermock';
 import nock, { RequestBodyMatcher } from 'nock';
-import querystring from 'querystring';
 import TestRail from '..';
+
+export { qs } from '../src/qs';
 
 chai.use(chaiAsPromised).should();
 
@@ -17,10 +18,6 @@ export const host = 'https://dlenroc.testrail.com';
 export const username = 'Username';
 export const password = 'Password/Token';
 export const api = new TestRail({ host, username, password });
-
-export function qs(obj: Record<any, any>) {
-  return querystring.stringify(obj);
-}
 
 export function on(path: string, requestBody?: RequestBodyMatcher | any) {
   const options = {


### PR DESCRIPTION
Is very annoying to always pass `1`/`0` or comma separated list in methods like `getRuns`/`getPlans`/`getCases`.

**so I added transform for qs parameters**
* `boolean` to `1`/`0`
*  `any[]` to a comma separated `any`
