### PR TITLE
feat(node): reuse TCP connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,12 @@
     "src",
     "dist"
   ],
+  "types": "dist/TestRail.d.ts",
   "main": "dist/TestRail.node.js",
   "module": "dist/TestRail.node.mjs",
   "browser": "dist/TestRail.browser.mjs",
   "jsdelivr": "dist/TestRail.umd.js",
   "unpkg": "dist/TestRail.umd.js",
-  "types": "dist/TestRail.d.ts",
-  "exports": {
-    "node": "./dist/TestRail.node.js",
-    "default": "./dist/TestRail.browser.mjs"
-  },
   "scripts": {
     "prepare": "npm run build",
     "build": "rollup -c && replace-in-file 'export default TestRail;' 'export default TestRail; export = TestRail;' dist/TestRail.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,30 +1,11 @@
-import pkg from './package.json';
-import {terser} from 'rollup-plugin-terser';
+import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
+import pkg from './package.json';
 
 export default {
   input: 'src/TestRail.ts',
   external: [],
   output: [
-    {
-      file: pkg.main,
-      format: 'cjs',
-      exports: 'default',
-      strict: false,
-      sourcemap: true,
-      banner: `'use strict';\n`
-        + `const fetch = require('node-fetch');\n`
-        + `const FormData = require('form-data');\n`
-    },
-    {
-      file: pkg.module,
-      format: 'es',
-      exports: 'default',
-      sourcemap: true,
-      banner: ``
-        + `import fetch from 'node-fetch';\n`
-        + `import FormData from 'form-data';\n`
-    },
     {
       file: pkg.browser,
       format: 'es',
@@ -37,10 +18,43 @@ export default {
       exports: 'default',
       sourcemap: true,
       name: 'TestRail'
+    },
+    {
+      file: pkg.main,
+      format: 'cjs',
+      exports: 'default',
+      strict: false,
+      sourcemap: true,
+      banner: `'use strict';\n`
+        + `const http = require('http');\n`
+        + `const https = require('https');\n`
+        + `const nodeFetch = require('node-fetch');\n`
+        + `const FormData = require('form-data');\n\n`
+        + `const options = { keepAlive: true };\n`
+        + `const httpAgent = new http.Agent(options);\n`
+        + `const httpsAgent = new https.Agent(options);\n`
+        + `const agent = (url) => url.protocol === 'http:' ? httpAgent : httpsAgent;\n`
+        + `const fetch = (url, init) => nodeFetch(url, { agent, ...init });\n`,
+    },
+    {
+      file: pkg.module,
+      format: 'es',
+      exports: 'default',
+      sourcemap: true,
+      banner: ``
+        + `import http from 'http';\n`
+        + `import https from 'https';\n`
+        + `import nodeFetch from 'node-fetch';\n`
+        + `import FormData from 'form-data';\n\n`
+        + `const options = { keepAlive: true };\n`
+        + `const httpAgent = new http.Agent(options);\n`
+        + `const httpsAgent = new https.Agent(options);\n`
+        + `const agent = (url) => url.protocol === 'http:' ? httpAgent : httpsAgent;\n`
+        + `const fetch = (url, init) => nodeFetch(url, { agent, ...init });\n`,
     }
   ],
   plugins: [
-    typescript({useTsconfigDeclarationDir: true}),
+    typescript({ useTsconfigDeclarationDir: true }),
     terser()
   ]
 }


### PR DESCRIPTION
[node-fetch](https://github.com/node-fetch/node-fetch) does not reuse TCP connections by default,  but provides a way to do so through the [http](https://nodejs.org/api/http.html#http_new_agent_options) / [https](https://nodejs.org/api/https.html#https_new_agent_options) agent.

> After enabling connection reuse, all subsequent exchanges became 2-3 times faster.