### PR TITLE
ci: remove unnecessary step

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,5 +17,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run build
       - run: npm test


### PR DESCRIPTION
Reduces CI execution time by 3 seconds by removing the `npm run build` step