### PR TITLE
fix: maximum redirects reached in `node-fetch@2.6.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "form-data": "^4",
-    "node-fetch": "^2"
+    "node-fetch": "2.6.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",


### PR DESCRIPTION
node-fetch 2.6.3 is incompatible with the testrail api, so for a quick fix I will temporarily switch to 2.6.2

see: https://github.com/node-fetch/node-fetch/issues/1300