### PR TITLE
fix: restore `node-fetch` version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "form-data": "^4",
-    "node-fetch": "2.6.2"
+    "node-fetch": "^2.6.4"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",


### PR DESCRIPTION
Issue with query parameters has been fixed in node-fetch 2.6.4, so now i'm going to put version range back