### PR TITLE
fix: pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-fetch": "^2.6.4"
   },
   "devDependencies": {
-    "@faker-js/faker": "^6.0.0-alpha.7",
+    "@faker-js/faker": "^6.1.2",
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.5",
     "@types/deasync": "^0.1.2",
@@ -43,15 +43,15 @@
     "@types/node": "*",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "deasync": "^0.1.24",
+    "deasync": "^0.1.26",
     "glob": "^7.2.0",
     "intermock": "^0.2.5",
-    "mocha": "^9.2.1",
+    "mocha": "^9.2.2",
     "nock": "^13.2.4",
-    "rollup": "^2.69.1",
+    "rollup": "^2.70.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
-    "ts-node": "^10.6.0",
-    "typescript": "^4.6.2"
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.3"
   }
 }

--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -601,9 +601,7 @@ async function pagination<T>(key: string, filters: any, callback: (filters: any)
     offset = page++ * limit;
 
     let items = await pagination<T>(key, { ...filters, limit, offset }, callback);
-    items = items.filter((item: any) => (ids.has(item.id) ? false : ids.add(item.id)));
-
-    results.push(...items);
+    results.push(...items.filter((item: any) => (ids.has(item.id) ? false : ids.add(item.id))));
 
     if (items.length != limit) {
       break;


### PR DESCRIPTION
previously pagination used filtered elements to determine if the next page should be loaded (which was wrong) so in this PR I made a small change what will use original items instead of filtered