### PR TITLE
fix: use `_links.next` if available

### DIFF
--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -593,20 +593,37 @@ async function pagination<T>(key: string, filters: any, callback: (filters: any)
 
   let page = 0;
   let offset = 0;
+  let result, items, hasNextPage, hasNewItems;
+
   const limit = 250;
   const results = [];
   const ids = new Set();
 
-  while (true) {
+  do {
     offset = page++ * limit;
+    result = await callback({ ...filters, limit, offset });
 
-    let items = await pagination<T>(key, { ...filters, limit, offset }, callback);
-    results.push(...items.filter((item: any) => (ids.has(item.id) ? false : ids.add(item.id))));
-
-    if (items.length != limit) {
-      break;
+    // API version < 6.7
+    if (Array.isArray(result)) {
+      hasNewItems = false;
+      hasNextPage = result.length === limit;
+      items = result;
+    } else {
+      hasNewItems = true;
+      hasNextPage = !!result?._links?.next;
+      items = result[key] || [];
     }
-  }
+
+    // Filter out duplicates
+    for (const item of items) {
+      if (!ids.has(item.id)) {
+        ids.add(item.id);
+        results.push(item);
+
+        hasNewItems = true;
+      }
+    }
+  } while (hasNextPage && hasNewItems);
 
   return results;
 }

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -1,0 +1,131 @@
+import { faker } from '@faker-js/faker';
+import { Case } from '..';
+import { api, jsonFor, OK, on } from './_helper';
+
+describe('Pagination', () => {
+  const projectId = faker.datatype.number();
+  const testCase: Case = jsonFor('Case');
+  const testCases = Array(1000)
+    .fill(null)
+    .map((_, id) => ({ ...testCase, id }));
+
+  describe('Common', async () => {
+    it('no paginate: "limit" passed', async () => {
+      const limit = faker.datatype.number();
+
+      on(`get_cases/${projectId}&limit=${limit}`)
+        .reply(OK);
+
+      await api.getCases(projectId, { limit });
+    });
+
+    it('no paginate: "offset" passed', async () => {
+      const offset = faker.datatype.number();
+
+      on(`get_cases/${projectId}&offset=${offset}`)
+        .reply(OK);
+
+      await api.getCases(projectId, { offset });
+    });
+  });
+
+  describe('TestRail < 6.7', async () => {
+    it('no paginate: <250 items', async () => {
+      const cases = testCases.slice(0, 249);
+
+      on(`get_cases/${projectId}&limit=250&offset=0`)
+        .reply(OK, cases);
+
+      await api
+        .getCases(projectId)
+        .should.eventually.be.deep.equal(cases);
+    });
+
+    it('no paginate: >250 items', async () => {
+      const cases = testCases.slice(0, 500);
+
+      on(`get_cases/${projectId}&limit=250&offset=0`)
+        .reply(OK, cases);
+
+      await api.getCases(projectId)
+        .should.eventually.be.deep.equal(cases);
+    });
+
+    it('no paginate: same items', async () => {
+      const response = testCases.slice(0, 250);
+
+      on(`get_cases/${projectId}&limit=250&offset=0`)
+        .reply(OK, response);
+
+      on(`get_cases/${projectId}&limit=250&offset=250`)
+        .reply(OK, response);
+
+      await api
+        .getCases(projectId)
+        .should.eventually.be.deep.equal(response);
+    });
+
+    it('paginate: partial duplication', async () => {
+      const firstResponse = testCases.slice(0, 250);
+      const secondResponse = testCases.slice(200, 450); // 50 duplications
+      const thirdResponse = testCases.slice(450, 699);
+      const allCases = testCases.slice(0, 699);
+
+      on(`get_cases/${projectId}&limit=250&offset=0`)
+        .reply(OK, firstResponse);
+
+      on(`get_cases/${projectId}&limit=250&offset=250`)
+        .reply(OK, secondResponse);
+
+      on(`get_cases/${projectId}&limit=250&offset=500`)
+        .reply(OK, thirdResponse);
+
+      await api
+        .getCases(projectId)
+        .should.eventually.be.deep.equal(allCases);
+    });
+  });
+
+  describe('TestRail >= 6.7', async () => {
+    it('no paginate: "_links.next" misses', async () => {
+      const response = {
+        _links: { next: null },
+        cases: testCases.slice(0, 250),
+      };
+
+      on(`get_cases/${projectId}&limit=250&offset=0`)
+        .reply(OK, response);
+
+      await api
+        .getCases(projectId)
+        .should.eventually.be.deep.equal(response.cases);
+    });
+
+    it('paginate: "_links.next" present', async () => {
+      const response = {
+        _links: { next: faker.internet.url() },
+        cases: testCases.slice(0, 250),
+      };
+
+      const lastResponse = {
+        cases: testCases.slice(250, 500),
+      };
+
+      const allCases = [...response.cases, ...lastResponse.cases];
+
+      on(`get_cases/${projectId}&limit=250&offset=0`)
+        .reply(OK, response);
+
+      // duplicates don't affect pagination
+      on(`get_cases/${projectId}&limit=250&offset=250`)
+        .reply(OK, response);
+
+      on(`get_cases/${projectId}&limit=250&offset=500`)
+        .reply(OK, lastResponse);
+
+      await api
+        .getCases(projectId)
+        .should.eventually.be.deep.equal(allCases);
+    });
+  });
+});


### PR DESCRIPTION
updated built-in pagination logic to rely on `_links.next` field