### PR TITLE
fix: typescript support

### DIFF
--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -1,15 +1,19 @@
-import { Request, Response } from './payload';
+import type { Request, Response } from './payload';
 import { stringify as qs } from './query-string';
 import { TestRailException } from './TestRailException';
 
 export * from './payload';
 export type { Request as Payload, Response as Model };
 
+declare class FormData { append(...args: any): void };
+declare var fetch: any;
+declare var window: any;
+
 class TestRail {
   static Exception = TestRailException;
-  private readonly username?: string;
-  private readonly password?: string;
   private readonly baseURL: string;
+  private readonly username: string | undefined;
+  private readonly password: string | undefined;
 
   constructor(config?: { host: string; username: string; password: string }) {
     // @ts-ignore - Backward compatibility
@@ -566,7 +570,7 @@ class TestRail {
 
   // Internal
 
-  private async _api<T>(method: string, path: string, { query, json, form }: { query?: object; json?: object; form?: object } = {}): Promise<T> {
+  private async _api<T>(method: string, path: string, { query, json, form }: { query?: object | undefined; json?: object | undefined; form?: object } = {}): Promise<T> {
     const headers: any = {};
     const url = this.baseURL + path + qs(query);
 

--- a/src/payload/index.ts
+++ b/src/payload/index.ts
@@ -1,5 +1,5 @@
-import * as Request from './request';
-import * as Response from './response';
+import type * as Request from './request';
+import type * as Response from './response';
 
 export * from './request';
 export * from './response';

--- a/src/payload/request/AddConfig.ts
+++ b/src/payload/request/AddConfig.ts
@@ -1,3 +1,3 @@
-import { AddConfigGroup } from './AddConfigGroup';
+import type { AddConfigGroup } from './AddConfigGroup';
 
 export type AddConfig = AddConfigGroup;

--- a/src/payload/request/AddPlan.ts
+++ b/src/payload/request/AddPlan.ts
@@ -1,5 +1,5 @@
-import { AddPlanEntry } from './AddPlanEntry';
-import { UpdatePlan } from './UpdatePlan';
+import type { AddPlanEntry } from './AddPlanEntry';
+import type { UpdatePlan } from './UpdatePlan';
 
 export interface AddPlan extends UpdatePlan {
   entries?: AddPlanEntry[];

--- a/src/payload/request/AddPlanEntry.ts
+++ b/src/payload/request/AddPlanEntry.ts
@@ -1,4 +1,4 @@
-import { AddRunToPlanEntry } from './AddRunToPlanEntry';
+import type { AddRunToPlanEntry } from './AddRunToPlanEntry';
 
 export interface AddPlanEntry extends Record<string, unknown> {
   suite_id?: number;

--- a/src/payload/request/AddResultForCase.ts
+++ b/src/payload/request/AddResultForCase.ts
@@ -1,4 +1,4 @@
-import { AddResult } from './AddResult';
+import type { AddResult } from './AddResult';
 
 export interface AddResultForCase extends AddResult {
   case_id?: number;

--- a/src/payload/request/AddResultForTest.ts
+++ b/src/payload/request/AddResultForTest.ts
@@ -1,4 +1,4 @@
-import { AddResult } from './AddResult';
+import type { AddResult } from './AddResult';
 
 export interface AddResultForTest extends AddResult {
   test_id?: number;

--- a/src/payload/request/AddResults.ts
+++ b/src/payload/request/AddResults.ts
@@ -1,4 +1,4 @@
-import { AddResultForTest } from './AddResultForTest';
+import type { AddResultForTest } from './AddResultForTest';
 
 export interface AddResults extends Record<string, unknown> {
   results?: AddResultForTest[];

--- a/src/payload/request/AddResultsForCases.ts
+++ b/src/payload/request/AddResultsForCases.ts
@@ -1,4 +1,4 @@
-import { AddResultForCase } from './AddResultForCase';
+import type { AddResultForCase } from './AddResultForCase';
 
 export interface AddResultsForCases extends Record<string, unknown> {
   results?: AddResultForCase[];

--- a/src/payload/request/AddRun.ts
+++ b/src/payload/request/AddRun.ts
@@ -1,4 +1,4 @@
-import { UpdateRun } from './UpdateRun';
+import type { UpdateRun } from './UpdateRun';
 
 export interface AddRun extends UpdateRun {
   suite_id?: number;

--- a/src/payload/request/AddSection.ts
+++ b/src/payload/request/AddSection.ts
@@ -1,4 +1,4 @@
-import { UpdateSection } from './UpdateSection';
+import type { UpdateSection } from './UpdateSection';
 
 export interface AddSection extends UpdateSection {
   parent_id?: number;

--- a/src/payload/request/CaseFilters.ts
+++ b/src/payload/request/CaseFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface CaseFilters extends Pagination, Record<string, unknown> {
   suite_id?: number;

--- a/src/payload/request/MilestoneFilters.ts
+++ b/src/payload/request/MilestoneFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface MilestoneFilters extends Pagination, Record<string, unknown> {
   is_completed?: boolean;

--- a/src/payload/request/PlanFilters.ts
+++ b/src/payload/request/PlanFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface PlanFilters extends Pagination, Record<string, unknown> {
   created_after?: number;

--- a/src/payload/request/ProjectFilters.ts
+++ b/src/payload/request/ProjectFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface ProjectFilters extends Pagination, Record<string, unknown> {
   is_completed?: boolean;

--- a/src/payload/request/ResultFilters.ts
+++ b/src/payload/request/ResultFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface ResultFilters extends Pagination, Record<string, unknown> {
   defects?: string;

--- a/src/payload/request/ResultForRunFilters.ts
+++ b/src/payload/request/ResultForRunFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface ResultForRunFilters extends Pagination, Record<string, unknown> {
   created_after?: number;

--- a/src/payload/request/RunFilters.ts
+++ b/src/payload/request/RunFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface RunFilters extends Pagination, Record<string, unknown> {
   created_after?: number;

--- a/src/payload/request/SectionFilters.ts
+++ b/src/payload/request/SectionFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface SectionFilters extends Pagination, Record<string, unknown> {
   suite_id?: number;

--- a/src/payload/request/SharedStepFilters.ts
+++ b/src/payload/request/SharedStepFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface SharedStepFilters extends Pagination, Record<string, unknown> {
   created_after?: number;

--- a/src/payload/request/TestFilters.ts
+++ b/src/payload/request/TestFilters.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './Pagination';
+import type { Pagination } from './Pagination';
 
 export interface TestFilters extends Pagination, Record<string, unknown> {
   status_id?: number | number[];

--- a/src/payload/request/UpdateCase.ts
+++ b/src/payload/request/UpdateCase.ts
@@ -1,4 +1,4 @@
-import { AddCase } from './AddCase';
+import type { AddCase } from './AddCase';
 
 export interface UpdateCase extends AddCase {
   section_id?: number;

--- a/src/payload/request/UpdateCases.ts
+++ b/src/payload/request/UpdateCases.ts
@@ -1,4 +1,4 @@
-import { UpdateCase } from './UpdateCase';
+import type { UpdateCase } from './UpdateCase';
 
 export interface UpdateCases extends UpdateCase {
   case_ids?: number[];

--- a/src/payload/request/UpdateConfig.ts
+++ b/src/payload/request/UpdateConfig.ts
@@ -1,3 +1,3 @@
-import { AddConfigGroup } from './AddConfigGroup';
+import type { AddConfigGroup } from './AddConfigGroup';
 
 export type UpdateConfig = AddConfigGroup;

--- a/src/payload/request/UpdateConfigGroup.ts
+++ b/src/payload/request/UpdateConfigGroup.ts
@@ -1,3 +1,3 @@
-import { AddConfigGroup } from './AddConfigGroup';
+import type { AddConfigGroup } from './AddConfigGroup';
 
 export type UpdateConfigGroup = AddConfigGroup;

--- a/src/payload/request/UpdateMilestone.ts
+++ b/src/payload/request/UpdateMilestone.ts
@@ -1,4 +1,4 @@
-import { AddMilestone } from './AddMilestone';
+import type { AddMilestone } from './AddMilestone';
 
 export interface UpdateMilestone extends AddMilestone {
   is_completed?: boolean;

--- a/src/payload/request/UpdateProject.ts
+++ b/src/payload/request/UpdateProject.ts
@@ -1,3 +1,3 @@
-import { AddProject } from './AddProject';
+import type { AddProject } from './AddProject';
 
 export type UpdateProject = AddProject;

--- a/src/payload/request/UpdateSharedStep.ts
+++ b/src/payload/request/UpdateSharedStep.ts
@@ -1,3 +1,3 @@
-import { AddSharedStep } from './AddSharedStep';
+import type { AddSharedStep } from './AddSharedStep';
 
 export type UpdateSharedStep = AddSharedStep;

--- a/src/payload/request/UpdateSuite.ts
+++ b/src/payload/request/UpdateSuite.ts
@@ -1,3 +1,3 @@
-import { AddSuite } from './AddSuite';
+import type { AddSuite } from './AddSuite';
 
 export type UpdateSuite = AddSuite;

--- a/src/payload/response/AttachmentForCase.ts
+++ b/src/payload/response/AttachmentForCase.ts
@@ -1,4 +1,4 @@
-import { Attachment } from './Attachment';
+import type { Attachment } from './Attachment';
 
 export interface AttachmentForCase extends Attachment {
   entity_type: 'case';

--- a/src/payload/response/AttachmentForPlan.ts
+++ b/src/payload/response/AttachmentForPlan.ts
@@ -1,4 +1,4 @@
-import { Attachment } from './Attachment';
+import type { Attachment } from './Attachment';
 
 export interface AttachmentForPlan extends Attachment {
   entity_type: 'plan';

--- a/src/payload/response/AttachmentForPlanEntry.ts
+++ b/src/payload/response/AttachmentForPlanEntry.ts
@@ -1,4 +1,4 @@
-import { Attachment } from './Attachment';
+import type { Attachment } from './Attachment';
 
 export interface AttachmentForPlanEntry extends Attachment {
   entity_type: 'entry';

--- a/src/payload/response/AttachmentForRun.ts
+++ b/src/payload/response/AttachmentForRun.ts
@@ -1,4 +1,4 @@
-import { Attachment } from './Attachment';
+import type { Attachment } from './Attachment';
 
 export interface AttachmentForRun extends Attachment {
   entity_type: 'run';

--- a/src/payload/response/AttachmentForTest.ts
+++ b/src/payload/response/AttachmentForTest.ts
@@ -1,4 +1,4 @@
-import { Attachment } from './Attachment';
+import type { Attachment } from './Attachment';
 
 export interface AttachmentForTest extends Attachment {
   entity_type: 'test_change';

--- a/src/payload/response/CaseField.ts
+++ b/src/payload/response/CaseField.ts
@@ -1,4 +1,4 @@
-import { Context } from './Context';
+import type { Context } from './Context';
 
 export interface CaseField extends Record<string, unknown> {
   configs: CaseField.CaseFieldConfig[];

--- a/src/payload/response/CaseHistory.ts
+++ b/src/payload/response/CaseHistory.ts
@@ -1,4 +1,4 @@
-import { Option } from './Option';
+import type { Option } from './Option';
 
 export interface CaseHistory extends Record<string, unknown> {
   changes: CaseHistory.Change[];

--- a/src/payload/response/Config.ts
+++ b/src/payload/response/Config.ts
@@ -1,4 +1,4 @@
-import { ConfigItem } from './ConfigItem';
+import type { ConfigItem } from './ConfigItem';
 
 export interface Config extends Record<string, unknown> {
   configs: ConfigItem[];

--- a/src/payload/response/Dataset.ts
+++ b/src/payload/response/Dataset.ts
@@ -1,4 +1,4 @@
-import { Variable } from './Variables';
+import type { Variable } from './Variables';
 
 export interface Dataset extends Record<string, unknown> {
   id: number;

--- a/src/payload/response/FieldConfig.ts
+++ b/src/payload/response/FieldConfig.ts
@@ -1,5 +1,5 @@
-import { Context } from './Context';
-import { Option } from './Option';
+import type { Context } from './Context';
+import type { Option } from './Option';
 
 export interface FieldConfig extends Record<string, unknown> {
   context: Context;

--- a/src/payload/response/Plan.ts
+++ b/src/payload/response/Plan.ts
@@ -1,4 +1,4 @@
-import { PlanEntry } from './PlanEntry';
+import type { PlanEntry } from './PlanEntry';
 
 export interface Plan extends Record<string, unknown> {
   assignedto_id?: number;

--- a/src/payload/response/PlanEntry.ts
+++ b/src/payload/response/PlanEntry.ts
@@ -1,4 +1,4 @@
-import { PlanEntryRun } from './PlanEntryRun';
+import type { PlanEntryRun } from './PlanEntryRun';
 
 export interface PlanEntry extends Record<string, unknown> {
   description?: string;

--- a/src/payload/response/ResultField.ts
+++ b/src/payload/response/ResultField.ts
@@ -1,4 +1,4 @@
-import { FieldConfig } from './FieldConfig';
+import type { FieldConfig } from './FieldConfig';
 
 export interface ResultField extends Record<string, unknown> {
   configs: FieldConfig[];

--- a/src/payload/response/SharedStepHistory.ts
+++ b/src/payload/response/SharedStepHistory.ts
@@ -1,4 +1,4 @@
-import { SharedStep } from './SharedStep';
+import type { SharedStep } from './SharedStep';
 
 export interface SharedStepHistory extends Record<string, unknown> {
   custom_steps_separated: SharedStep['custom_steps_separated'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "outDir": "./dist",
     "target": "ES2018",
     "lib": [
-      "DOM",
       "ES2018"
     ],
     "sourceMap": true,


### PR DESCRIPTION
#62 showed that this library does not pass type checking when used in typescript projects without a DOM library, and that in this case typescript does not understand the `typeof <name> !== 'undefined'` syntax used for checking presence of variables.

Verified thought:
- `ts testrail-bug.ts`
- `tsc --esModuleInterop true testrail-bug.ts`
