### PR TITLE
feat: `signal` for each endpoint

### DIFF
--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -7,7 +7,6 @@ export * from './payload';
 export type { Request as Payload, Response as Model };
 
 type Signal = { signal: AbortSignal };
-type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 export default class TestRail {
   static Exception = TestRailException;
@@ -26,502 +25,493 @@ export default class TestRail {
   }
 
   addAttachmentToCase(caseId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
-    return methods.addAttachmentToCase(this.getCtx(options), caseId, payload);
+    return this.withCtx(options, (ctx) => methods.addAttachmentToCase(ctx, caseId, payload));
   }
 
   addAttachmentToPlan(planId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
-    return methods.addAttachmentToPlan(this.getCtx(options), planId, payload);
+    return this.withCtx(options, (ctx) => methods.addAttachmentToPlan(ctx, planId, payload));
   }
 
   addAttachmentToPlanEntry(planId: number, entryId: string, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
-    return methods.addAttachmentToPlanEntry(this.getCtx(options), planId, entryId, payload);
+    return this.withCtx(options, (ctx) => methods.addAttachmentToPlanEntry(ctx, planId, entryId, payload));
   }
 
   addAttachmentToResult(resultId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
-    return methods.addAttachmentToResult(this.getCtx(options), resultId, payload);
+    return this.withCtx(options, (ctx) => methods.addAttachmentToResult(ctx, resultId, payload));
   }
 
   addAttachmentToRun(runId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
-    return methods.addAttachmentToRun(this.getCtx(options), runId, payload);
+    return this.withCtx(options, (ctx) => methods.addAttachmentToRun(ctx, runId, payload));
   }
 
   getAttachmentsForCase(caseId: number, filters?: Pagination, options?: Signal): Promise<AttachmentForCase[]> {
-    return methods.getAttachmentsForCase(this.getCtx(options), caseId, filters);
+    return this.withCtx(options, (ctx) => methods.getAttachmentsForCase(ctx, caseId, filters));
   }
 
   getAttachmentsForPlan(planId: number, filters?: Pagination, options?: Signal): Promise<AttachmentForPlan[]> {
-    return methods.getAttachmentsForPlan(this.getCtx(options), planId, filters);
+    return this.withCtx(options, (ctx) => methods.getAttachmentsForPlan(ctx, planId, filters));
   }
 
   getAttachmentsForPlanEntry(planId: number, entryId: string, options?: Signal): Promise<AttachmentForPlanEntry[]> {
-    return methods.getAttachmentsForPlanEntry(this.getCtx(options), planId, entryId);
+    return this.withCtx(options, (ctx) => methods.getAttachmentsForPlanEntry(ctx, planId, entryId));
   }
 
   getAttachmentsForRun(runId: number, filters?: Pagination, options?: Signal): Promise<AttachmentForRun[]> {
-    return methods.getAttachmentsForRun(this.getCtx(options), runId, filters);
+    return this.withCtx(options, (ctx) => methods.getAttachmentsForRun(ctx, runId, filters));
   }
 
   getAttachmentsForTest(testId: number, options?: Signal): Promise<AttachmentForTest[]> {
-    return methods.getAttachmentsForTest(this.getCtx(options), testId);
+    return this.withCtx(options, (ctx) => methods.getAttachmentsForTest(ctx, testId));
   }
 
   getAttachment(attachmentId: string, options?: Signal): Promise<Blob> {
-    return methods.getAttachment(this.getCtx(options), attachmentId);
+    return this.withCtx(options, (ctx) => methods.getAttachment(ctx, attachmentId));
   }
 
   deleteAttachment(attachmentId: string, options?: Signal): Promise<void> {
-    return methods.deleteAttachment(this.getCtx(options), attachmentId);
+    return this.withCtx(options, (ctx) => methods.deleteAttachment(ctx, attachmentId));
   }
 
   getBdd(caseId: number, options?: Signal): Promise<Blob> {
-    return methods.getBdd(this.getCtx(options), caseId);
+    return this.withCtx(options, (ctx) => methods.getBdd(ctx, caseId));
   }
 
   addBdd(sectionId: number, payload: AddAttachment, options?: Signal): Promise<Case> {
-    return methods.addBdd(this.getCtx(options), sectionId, payload);
+    return this.withCtx(options, (ctx) => methods.addBdd(ctx, sectionId, payload));
   }
 
   getCase(caseId: number, options?: Signal): Promise<Case> {
-    return methods.getCase(this.getCtx(options), caseId);
+    return this.withCtx(options, (ctx) => methods.getCase(ctx, caseId));
   }
 
   getCases(projectId: number, filters?: CaseFilters, options?: Signal): Promise<Case[]> {
-    return methods.getCases(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getCases(ctx, projectId, filters));
   }
 
   getHistoryForCase(caseId: number, filters?: Pagination, options?: Signal): Promise<CaseHistory[]> {
-    return methods.getHistoryForCase(this.getCtx(options), caseId, filters);
+    return this.withCtx(options, (ctx) => methods.getHistoryForCase(ctx, caseId, filters));
   }
 
   addCase(sectionId: number, payload: AddCase, options?: Signal): Promise<Case> {
-    return methods.addCase(this.getCtx(options), sectionId, payload);
+    return this.withCtx(options, (ctx) => methods.addCase(ctx, sectionId, payload));
   }
 
   copyCasesToSection(sectionId: number, payload: CopyCasesToSection, options?: Signal): Promise<void> {
-    return methods.copyCasesToSection(this.getCtx(options), sectionId, payload);
+    return this.withCtx(options, (ctx) => methods.copyCasesToSection(ctx, sectionId, payload));
   }
 
   updateCase(caseId: number, payload: UpdateCase, options?: Signal): Promise<Case> {
-    return methods.updateCase(this.getCtx(options), caseId, payload);
+    return this.withCtx(options, (ctx) => methods.updateCase(ctx, caseId, payload));
   }
 
   updateCases(suiteId: number, payload: UpdateCases, options?: Signal): Promise<void> {
-    return methods.updateCases(this.getCtx(options), suiteId, payload);
+    return this.withCtx(options, (ctx) => methods.updateCases(ctx, suiteId, payload));
   }
 
   moveCasesToSection(sectionId: number, payload: MoveCasesToSection, options?: Signal): Promise<void> {
-    return methods.moveCasesToSection(this.getCtx(options), sectionId, payload);
+    return this.withCtx(options, (ctx) => methods.moveCasesToSection(ctx, sectionId, payload));
   }
 
   deleteCase(caseId: number, options?: Signal): Promise<void> {
-    return methods.deleteCase(this.getCtx(options), caseId);
+    return this.withCtx(options, (ctx) => methods.deleteCase(ctx, caseId));
   }
 
   deleteCases(suiteId: number, payload: DeleteCases, options?: Signal): Promise<void> {
-    return methods.deleteCases(this.getCtx(options), suiteId, payload);
+    return this.withCtx(options, (ctx) => methods.deleteCases(ctx, suiteId, payload));
   }
 
   getCaseFields(options?: Signal): Promise<CaseField[]> {
-    return methods.getCaseFields(this.getCtx(options));
+    return this.withCtx(options, (ctx) => methods.getCaseFields(ctx));
   }
 
   addCaseField(payload: AddCaseField, options?: Signal): Promise<CaseField> {
-    return methods.addCaseField(this.getCtx(options), payload);
+    return this.withCtx(options, (ctx) => methods.addCaseField(ctx, payload));
   }
 
   getCaseTypes(options?: Signal): Promise<CaseType[]> {
-    return methods.getCaseTypes(this.getCtx(options));
+    return this.withCtx(options, (ctx) => methods.getCaseTypes(ctx));
   }
 
   getConfigs(projectId: number, options?: Signal): Promise<Config[]> {
-    return methods.getConfigs(this.getCtx(options), projectId);
+    return this.withCtx(options, (ctx) => methods.getConfigs(ctx, projectId));
   }
 
   addConfigGroup(projectId: number, payload: AddConfigGroup, options?: Signal): Promise<Config> {
-    return methods.addConfigGroup(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addConfigGroup(ctx, projectId, payload));
   }
 
   addConfig(configGroupId: number, payload: AddConfig, options?: Signal): Promise<ConfigItem> {
-    return methods.addConfig(this.getCtx(options), configGroupId, payload);
+    return this.withCtx(options, (ctx) => methods.addConfig(ctx, configGroupId, payload));
   }
 
   updateConfigGroup(configGroupId: number, payload: UpdateConfigGroup, options?: Signal): Promise<Config> {
-    return methods.updateConfigGroup(this.getCtx(options), configGroupId, payload);
+    return this.withCtx(options, (ctx) => methods.updateConfigGroup(ctx, configGroupId, payload));
   }
 
   updateConfig(configId: number, payload: UpdateConfig, options?: Signal): Promise<ConfigItem> {
-    return methods.updateConfig(this.getCtx(options), configId, payload);
+    return this.withCtx(options, (ctx) => methods.updateConfig(ctx, configId, payload));
   }
 
   deleteConfigGroup(configGroupId: number, options?: Signal): Promise<void> {
-    return methods.deleteConfigGroup(this.getCtx(options), configGroupId);
+    return this.withCtx(options, (ctx) => methods.deleteConfigGroup(ctx, configGroupId));
   }
 
   deleteConfig(configId: number, options?: Signal): Promise<void> {
-    return methods.deleteConfig(this.getCtx(options), configId);
+    return this.withCtx(options, (ctx) => methods.deleteConfig(ctx, configId));
   }
 
   getDataset(datasetId: number, options?: Signal): Promise<Dataset> {
-    return methods.getDataset(this.getCtx(options), datasetId);
+    return this.withCtx(options, (ctx) => methods.getDataset(ctx, datasetId));
   }
 
   getDatasets(projectId: number, filters?: Pagination, options?: Signal): Promise<Dataset[]> {
-    return methods.getDatasets(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getDatasets(ctx, projectId, filters));
   }
 
   addDataset(projectId: number, payload: AddDataset, options?: Signal): Promise<Group> {
-    return methods.addDataset(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addDataset(ctx, projectId, payload));
   }
 
   updateDataset(datasetId: number, payload: AddDataset, options?: Signal): Promise<Group> {
-    return methods.updateDataset(this.getCtx(options), datasetId, payload);
+    return this.withCtx(options, (ctx) => methods.updateDataset(ctx, datasetId, payload));
   }
 
   deleteDataset(datasetId: number, options?: Signal): Promise<void> {
-    return methods.deleteDataset(this.getCtx(options), datasetId);
+    return this.withCtx(options, (ctx) => methods.deleteDataset(ctx, datasetId));
   }
 
   getGroup(groupId: number, options?: Signal): Promise<Group> {
-    return methods.getGroup(this.getCtx(options), groupId);
+    return this.withCtx(options, (ctx) => methods.getGroup(ctx, groupId));
   }
 
   getGroups(filters?: Pagination, options?: Signal): Promise<Group[]> {
-    return methods.getGroups(this.getCtx(options), filters);
+    return this.withCtx(options, (ctx) => methods.getGroups(ctx, filters));
   }
 
   addGroup(payload: AddGroup, options?: Signal): Promise<Group> {
-    return methods.addGroup(this.getCtx(options), payload);
+    return this.withCtx(options, (ctx) => methods.addGroup(ctx, payload));
   }
 
   updateGroup(groupId: number, payload: AddGroup, options?: Signal): Promise<Group> {
-    return methods.updateGroup(this.getCtx(options), groupId, payload);
+    return this.withCtx(options, (ctx) => methods.updateGroup(ctx, groupId, payload));
   }
 
   deleteGroup(groupId: number, options?: Signal): Promise<void> {
-    return methods.deleteGroup(this.getCtx(options), groupId);
+    return this.withCtx(options, (ctx) => methods.deleteGroup(ctx, groupId));
   }
 
   getMilestone(milestoneId: number, options?: Signal): Promise<Milestone> {
-    return methods.getMilestone(this.getCtx(options), milestoneId);
+    return this.withCtx(options, (ctx) => methods.getMilestone(ctx, milestoneId));
   }
 
   getMilestones(projectId: number, filters?: MilestoneFilters, options?: Signal): Promise<Milestone[]> {
-    return methods.getMilestones(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getMilestones(ctx, projectId, filters));
   }
 
   addMilestone(projectId: number, payload: AddMilestone, options?: Signal): Promise<Milestone> {
-    return methods.addMilestone(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addMilestone(ctx, projectId, payload));
   }
 
   updateMilestone(milestoneId: number, payload: UpdateMilestone, options?: Signal): Promise<Milestone> {
-    return methods.updateMilestone(this.getCtx(options), milestoneId, payload);
+    return this.withCtx(options, (ctx) => methods.updateMilestone(ctx, milestoneId, payload));
   }
 
   deleteMilestone(milestoneId: number, options?: Signal): Promise<void> {
-    return methods.deleteMilestone(this.getCtx(options), milestoneId);
+    return this.withCtx(options, (ctx) => methods.deleteMilestone(ctx, milestoneId));
   }
 
   getPlan(planId: number, options?: Signal): Promise<Plan> {
-    return methods.getPlan(this.getCtx(options), planId);
+    return this.withCtx(options, (ctx) => methods.getPlan(ctx, planId));
   }
 
   getPlans(projectId: number, filters?: PlanFilters, options?: Signal): Promise<PlanItem[]> {
-    return methods.getPlans(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getPlans(ctx, projectId, filters));
   }
 
   addPlan(projectId: number, payload: AddPlan, options?: Signal): Promise<Plan> {
-    return methods.addPlan(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addPlan(ctx, projectId, payload));
   }
 
   addPlanEntry(planId: number, payload: AddPlanEntry, options?: Signal): Promise<PlanEntry> {
-    return methods.addPlanEntry(this.getCtx(options), planId, payload);
+    return this.withCtx(options, (ctx) => methods.addPlanEntry(ctx, planId, payload));
   }
 
   addRunToPlanEntry(planId: number, entryId: string, payload: AddRunToPlanEntry, options?: Signal): Promise<PlanEntry> {
-    return methods.addRunToPlanEntry(this.getCtx(options), planId, entryId, payload);
+    return this.withCtx(options, (ctx) => methods.addRunToPlanEntry(ctx, planId, entryId, payload));
   }
 
   updatePlan(planId: number, payload: UpdatePlan, options?: Signal): Promise<Plan> {
-    return methods.updatePlan(this.getCtx(options), planId, payload);
+    return this.withCtx(options, (ctx) => methods.updatePlan(ctx, planId, payload));
   }
 
   updatePlanEntry(planId: number, entryId: string, payload: UpdatePlanEntry, options?: Signal): Promise<PlanEntry> {
-    return methods.updatePlanEntry(this.getCtx(options), planId, entryId, payload);
+    return this.withCtx(options, (ctx) => methods.updatePlanEntry(ctx, planId, entryId, payload));
   }
 
   updateRunInPlanEntry(runId: number, payload: UpdateRunInPlanEntry, options?: Signal): Promise<PlanEntry> {
-    return methods.updateRunInPlanEntry(this.getCtx(options), runId, payload);
+    return this.withCtx(options, (ctx) => methods.updateRunInPlanEntry(ctx, runId, payload));
   }
 
   closePlan(planId: number, options?: Signal): Promise<Plan> {
-    return methods.closePlan(this.getCtx(options), planId);
+    return this.withCtx(options, (ctx) => methods.closePlan(ctx, planId));
   }
 
   deletePlan(planId: number, options?: Signal): Promise<void> {
-    return methods.deletePlan(this.getCtx(options), planId);
+    return this.withCtx(options, (ctx) => methods.deletePlan(ctx, planId));
   }
 
   deletePlanEntry(planId: number, entryId: string, options?: Signal): Promise<void> {
-    return methods.deletePlanEntry(this.getCtx(options), planId, entryId);
+    return this.withCtx(options, (ctx) => methods.deletePlanEntry(ctx, planId, entryId));
   }
 
   deleteRunFromPlanEntry(runId: number, options?: Signal): Promise<void> {
-    return methods.deleteRunFromPlanEntry(this.getCtx(options), runId);
+    return this.withCtx(options, (ctx) => methods.deleteRunFromPlanEntry(ctx, runId));
   }
 
   getPriorities(options?: Signal): Promise<Priority[]> {
-    return methods.getPriorities(this.getCtx(options));
+    return this.withCtx(options, (ctx) => methods.getPriorities(ctx));
   }
 
   getProject(projectId: number, options?: Signal): Promise<Project> {
-    return methods.getProject(this.getCtx(options), projectId);
+    return this.withCtx(options, (ctx) => methods.getProject(ctx, projectId));
   }
 
   getProjects(filters?: ProjectFilters, options?: Signal): Promise<Project[]> {
-    return methods.getProjects(this.getCtx(options), filters);
+    return this.withCtx(options, (ctx) => methods.getProjects(ctx, filters));
   }
 
   addProject(payload: AddProject, options?: Signal): Promise<Project> {
-    return methods.addProject(this.getCtx(options), payload);
+    return this.withCtx(options, (ctx) => methods.addProject(ctx, payload));
   }
 
   updateProject(projectId: number, payload: UpdateProject, options?: Signal): Promise<Project> {
-    return methods.updateProject(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.updateProject(ctx, projectId, payload));
   }
 
   deleteProject(projectId: number, options?: Signal): Promise<void> {
-    return methods.deleteProject(this.getCtx(options), projectId);
+    return this.withCtx(options, (ctx) => methods.deleteProject(ctx, projectId));
   }
 
   getReports(projectId: number, options?: Signal): Promise<Report[]> {
-    return methods.getReports(this.getCtx(options), projectId);
+    return this.withCtx(options, (ctx) => methods.getReports(ctx, projectId));
   }
 
   runReport(reportTemplateId: number, options?: Signal): Promise<ReportUrls> {
-    return methods.runReport(this.getCtx(options), reportTemplateId);
+    return this.withCtx(options, (ctx) => methods.runReport(ctx, reportTemplateId));
   }
 
   getResults(testId: number, filters?: ResultFilters, options?: Signal): Promise<Result[]> {
-    return methods.getResults(this.getCtx(options), testId, filters);
+    return this.withCtx(options, (ctx) => methods.getResults(ctx, testId, filters));
   }
 
   getResultsForCase(runId: number, caseId: number, filters?: ResultFilters, options?: Signal): Promise<Result[]> {
-    return methods.getResultsForCase(this.getCtx(options), runId, caseId, filters);
+    return this.withCtx(options, (ctx) => methods.getResultsForCase(ctx, runId, caseId, filters));
   }
 
   getResultsForRun(runId: number, filters?: ResultForRunFilters, options?: Signal): Promise<Result[]> {
-    return methods.getResultsForRun(this.getCtx(options), runId, filters);
+    return this.withCtx(options, (ctx) => methods.getResultsForRun(ctx, runId, filters));
   }
 
   addResult(testId: number, payload: AddResult, options?: Signal): Promise<Result> {
-    return methods.addResult(this.getCtx(options), testId, payload);
+    return this.withCtx(options, (ctx) => methods.addResult(ctx, testId, payload));
   }
 
   addResultForCase(runId: number, caseId: number, payload: AddResult, options?: Signal): Promise<Result> {
-    return methods.addResultForCase(this.getCtx(options), runId, caseId, payload);
+    return this.withCtx(options, (ctx) => methods.addResultForCase(ctx, runId, caseId, payload));
   }
 
   addResults(runId: number, payload: AddResults, options?: Signal): Promise<Result[]> {
-    return methods.addResults(this.getCtx(options), runId, payload);
+    return this.withCtx(options, (ctx) => methods.addResults(ctx, runId, payload));
   }
 
   addResultsForCases(runId: number, payload: AddResultsForCases, options?: Signal): Promise<Result[]> {
-    return methods.addResultsForCases(this.getCtx(options), runId, payload);
+    return this.withCtx(options, (ctx) => methods.addResultsForCases(ctx, runId, payload));
   }
 
   getResultFields(options?: Signal): Promise<ResultField[]> {
-    return methods.getResultFields(this.getCtx(options));
+    return this.withCtx(options, (ctx) => methods.getResultFields(ctx));
   }
 
   getRoles(filters?: Pagination, options?: Signal): Promise<Role[]> {
-    return methods.getRoles(this.getCtx(options), filters);
+    return this.withCtx(options, (ctx) => methods.getRoles(ctx, filters));
   }
 
   getRun(runId: number, options?: Signal): Promise<Run> {
-    return methods.getRun(this.getCtx(options), runId);
+    return this.withCtx(options, (ctx) => methods.getRun(ctx, runId));
   }
 
   getRuns(projectId: number, filters?: RunFilters, options?: Signal): Promise<Run[]> {
-    return methods.getRuns(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getRuns(ctx, projectId, filters));
   }
 
   addRun(projectId: number, payload: AddRun, options?: Signal): Promise<Run> {
-    return methods.addRun(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addRun(ctx, projectId, payload));
   }
 
   updateRun(runId: number, payload: UpdateRun, options?: Signal): Promise<Run> {
-    return methods.updateRun(this.getCtx(options), runId, payload);
+    return this.withCtx(options, (ctx) => methods.updateRun(ctx, runId, payload));
   }
 
   closeRun(runId: number, options?: Signal): Promise<Run> {
-    return methods.closeRun(this.getCtx(options), runId);
+    return this.withCtx(options, (ctx) => methods.closeRun(ctx, runId));
   }
 
   deleteRun(runId: number, options?: Signal): Promise<void> {
-    return methods.deleteRun(this.getCtx(options), runId);
+    return this.withCtx(options, (ctx) => methods.deleteRun(ctx, runId));
   }
 
   getSection(sectionId: number, options?: Signal): Promise<Section> {
-    return methods.getSection(this.getCtx(options), sectionId);
+    return this.withCtx(options, (ctx) => methods.getSection(ctx, sectionId));
   }
 
   getSections(projectId: number, filters?: SectionFilters, options?: Signal): Promise<Section[]> {
-    return methods.getSections(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getSections(ctx, projectId, filters));
   }
 
   addSection(projectId: number, payload: AddSection, options?: Signal): Promise<Section> {
-    return methods.addSection(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addSection(ctx, projectId, payload));
   }
 
   moveSection(sectionId: number, payload: MoveSection, options?: Signal): Promise<Section> {
-    return methods.moveSection(this.getCtx(options), sectionId, payload);
+    return this.withCtx(options, (ctx) => methods.moveSection(ctx, sectionId, payload));
   }
 
   updateSection(sectionId: number, payload: UpdateSection, options?: Signal): Promise<Section> {
-    return methods.updateSection(this.getCtx(options), sectionId, payload);
+    return this.withCtx(options, (ctx) => methods.updateSection(ctx, sectionId, payload));
   }
 
   deleteSection(sectionId: number, options?: Signal): Promise<void> {
-    return methods.deleteSection(this.getCtx(options), sectionId);
+    return this.withCtx(options, (ctx) => methods.deleteSection(ctx, sectionId));
   }
 
   getSharedStep(stepId: number, options?: Signal): Promise<SharedStep> {
-    return methods.getSharedStep(this.getCtx(options), stepId);
+    return this.withCtx(options, (ctx) => methods.getSharedStep(ctx, stepId));
   }
 
   getSharedSteps(projectId: number, filters?: SharedStepFilters, options?: Signal): Promise<SharedStep[]> {
-    return methods.getSharedSteps(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getSharedSteps(ctx, projectId, filters));
   }
 
   getSharedStepHistory(stepId: number, filters?: Pagination, options?: Signal): Promise<SharedStepHistory[]> {
-    return methods.getSharedStepHistory(this.getCtx(options), stepId, filters);
+    return this.withCtx(options, (ctx) => methods.getSharedStepHistory(ctx, stepId, filters));
   }
 
   addSharedStep(projectId: number, payload: AddSharedStep, options?: Signal): Promise<SharedStep> {
-    return methods.addSharedStep(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addSharedStep(ctx, projectId, payload));
   }
 
   updateSharedStep(stepId: number, payload: UpdateSharedStep, options?: Signal): Promise<SharedStep> {
-    return methods.updateSharedStep(this.getCtx(options), stepId, payload);
+    return this.withCtx(options, (ctx) => methods.updateSharedStep(ctx, stepId, payload));
   }
 
   deleteSharedStep(stepId: number, payload?: DeleteSharedStep, options?: Signal): Promise<void> {
-    return methods.deleteSharedStep(this.getCtx(options), stepId, payload);
+    return this.withCtx(options, (ctx) => methods.deleteSharedStep(ctx, stepId, payload));
   }
 
   getStatuses(options?: Signal): Promise<Status[]> {
-    return methods.getStatuses(this.getCtx(options));
+    return this.withCtx(options, (ctx) => methods.getStatuses(ctx));
   }
 
   getCaseStatuses(filters?: Pagination, options?: Signal): Promise<CaseStatus[]> {
-    return methods.getCaseStatuses(this.getCtx(options), filters);
+    return this.withCtx(options, (ctx) => methods.getCaseStatuses(ctx, filters));
   }
 
   getSuite(suiteId: number, options?: Signal): Promise<Suite> {
-    return methods.getSuite(this.getCtx(options), suiteId);
+    return this.withCtx(options, (ctx) => methods.getSuite(ctx, suiteId));
   }
 
   getSuites(projectId: number, options?: Signal): Promise<Suite[]> {
-    return methods.getSuites(this.getCtx(options), projectId);
+    return this.withCtx(options, (ctx) => methods.getSuites(ctx, projectId));
   }
 
   addSuite(projectId: number, payload: AddSuite, options?: Signal): Promise<Suite> {
-    return methods.addSuite(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addSuite(ctx, projectId, payload));
   }
 
   updateSuite(suiteId: number, payload: UpdateSuite, options?: Signal): Promise<Suite> {
-    return methods.updateSuite(this.getCtx(options), suiteId, payload);
+    return this.withCtx(options, (ctx) => methods.updateSuite(ctx, suiteId, payload));
   }
 
   deleteSuite(suiteId: number, options?: Signal): Promise<void> {
-    return methods.deleteSuite(this.getCtx(options), suiteId);
+    return this.withCtx(options, (ctx) => methods.deleteSuite(ctx, suiteId));
   }
 
   getTemplates(projectId: number, options?: Signal): Promise<Template[]> {
-    return methods.getTemplates(this.getCtx(options), projectId);
+    return this.withCtx(options, (ctx) => methods.getTemplates(ctx, projectId));
   }
 
   getTest(testId: number, options?: Signal): Promise<Test> {
-    return methods.getTest(this.getCtx(options), testId);
+    return this.withCtx(options, (ctx) => methods.getTest(ctx, testId));
   }
 
   getTests(runId: number, filters?: TestFilters, options?: Signal): Promise<Test[]> {
-    return methods.getTests(this.getCtx(options), runId, filters);
+    return this.withCtx(options, (ctx) => methods.getTests(ctx, runId, filters));
   }
 
   getUser(userId: number, options?: Signal): Promise<User> {
-    return methods.getUser(this.getCtx(options), userId);
+    return this.withCtx(options, (ctx) => methods.getUser(ctx, userId));
   }
 
   getCurrentUser(options?: Signal): Promise<User> {
-    return methods.getCurrentUser(this.getCtx(options));
+    return this.withCtx(options, (ctx) => methods.getCurrentUser(ctx));
   }
 
   getUserByEmail(email: string, options?: Signal): Promise<User> {
-    return methods.getUserByEmail(this.getCtx(options), email);
+    return this.withCtx(options, (ctx) => methods.getUserByEmail(ctx, email));
   }
 
   getUsers(filters?: UserFilters, options?: Signal): Promise<User[]> {
-    return methods.getUsers(this.getCtx(options), filters);
+    return this.withCtx(options, (ctx) => methods.getUsers(ctx, filters));
   }
 
   addUser(payload: AddUser, options?: Signal): Promise<User> {
-    return methods.addUser(this.getCtx(options), payload);
+    return this.withCtx(options, (ctx) => methods.addUser(ctx, payload));
   }
 
   updateUser(userId: number, payload: AddUser, options?: Signal): Promise<User> {
-    return methods.updateUser(this.getCtx(options), userId, payload);
+    return this.withCtx(options, (ctx) => methods.updateUser(ctx, userId, payload));
   }
 
   getVariables(projectId: number, filters?: Pagination, options?: Signal): Promise<Variable[]> {
-    return methods.getVariables(this.getCtx(options), projectId, filters);
+    return this.withCtx(options, (ctx) => methods.getVariables(ctx, projectId, filters));
   }
 
   addVariable(projectId: number, payload: AddVariable, options?: Signal): Promise<Variable> {
-    return methods.addVariable(this.getCtx(options), projectId, payload);
+    return this.withCtx(options, (ctx) => methods.addVariable(ctx, projectId, payload));
   }
 
   updateVariable(variableId: number, payload: AddVariable, options?: Signal): Promise<Variable> {
-    return methods.updateVariable(this.getCtx(options), variableId, payload);
+    return this.withCtx(options, (ctx) => methods.updateVariable(ctx, variableId, payload));
   }
 
   deleteVariable(variableId: number, options?: Signal): Promise<void> {
-    return methods.deleteVariable(this.getCtx(options), variableId);
+    return this.withCtx(options, (ctx) => methods.deleteVariable(ctx, variableId));
   }
 
-  private getCtx(options?: Signal): TestRailCtx {
-    const ctx: Mutable<TestRailCtx> = Object.create(this.ctx);
+  private withCtx<T>(options: Signal | undefined, callback: (ctx: TestRailCtx) => Promise<T>): Promise<T> {
+    const ctxSignal = this.ctx.signal;
+    const optionsSignal = options?.signal;
 
-    if (options?.signal) {
-      if (ctx.signal) {
-        // @ts-ignore - intentionally throws "ReferrerError" if "AbortController" is not available
-        const controller = new (ctx.implementations?.AbortController || AbortController)();
-
-        if (ctx.signal.aborted) {
-          controller.abort(ctx.signal.reason);
-        } else if (options.signal.aborted) {
-          controller.abort(options.signal.reason);
-        }
-
-        if (controller.signal.aborted) {
-          throw controller.signal.reason;
-        }
-
-        ctx.signal.addEventListener('abort', onAbort);
-        options.signal.addEventListener('abort', onAbort);
-
-        function onAbort() {
-          ctx.signal?.removeEventListener('abort', onAbort);
-          options?.signal.removeEventListener('abort', onAbort);
-          controller.abort(ctx.signal?.reason || options?.signal.reason);
-        }
-
-        ctx.signal = controller.signal;
-      } else {
-        ctx.signal = options.signal;
-      }
+    if (!optionsSignal) {
+      return callback(this.ctx);
     }
 
-    return ctx;
+    if (!ctxSignal) {
+      return callback(Object.assign({}, this.ctx, { signal: options.signal }));
+    }
+
+    if (ctxSignal.aborted || optionsSignal.aborted) {
+      throw ctxSignal.reason || options.signal.reason;
+    }
+
+    // @ts-ignore - intentionally throws "ReferrerError" if "AbortController" is not available
+    const controller = new (this.ctx.implementations?.AbortController || AbortController)();
+    const clearAbort = () => { ctxSignal.removeEventListener('abort', onAbort); optionsSignal.removeEventListener('abort', onAbort); };
+    const onAbort = () => { clearAbort(); controller.abort(ctxSignal.reason || optionsSignal.reason); };
+    ctxSignal.addEventListener('abort', onAbort);
+    optionsSignal.addEventListener('abort', onAbort);
+
+    return callback(Object.assign({}, this.ctx, { signal: controller.signal }))
+      .then((r) => { clearAbort(); return r; }, (e) => { clearAbort(); throw e; });
   }
 }

--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -501,7 +501,7 @@ export default class TestRail {
     }
 
     if (ctxSignal.aborted || optionsSignal.aborted) {
-      throw ctxSignal.reason || options.signal.reason;
+      return Promise.reject(ctxSignal.reason || options.signal.reason);
     }
 
     // @ts-ignore - intentionally throws "ReferrerError" if "AbortController" is not available

--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -13,7 +13,7 @@ export default class TestRail {
   static Exception = TestRailException;
   private readonly ctx: TestRailCtx;
 
-  constructor(config?: Pick<TestRailCtx, 'username' | 'password' | 'signal' | 'implementations'> & { host: string; }) {
+  constructor(config?: { host: string; username: string; password: string } & Pick<TestRailCtx, 'signal' | 'implementations'>) {
     this.ctx = {
       baseURL: (config?.host || '') + '/index.php?/api/v2/',
       // @ts-ignore - Backward compatibility

--- a/src/TestRail.ts
+++ b/src/TestRail.ts
@@ -1,489 +1,527 @@
 import type { TestRailCtx } from './TestRailCtx';
 import { TestRailException } from './TestRailException';
 import * as methods from './groups';
-import type { Request, Response } from './payload';
+import type { AddAttachment, AddCase, AddCaseField, AddConfig, AddConfigGroup, AddDataset, AddGroup, AddMilestone, AddPlan, AddPlanEntry, AddProject, AddResult, AddResults, AddResultsForCases, AddRun, AddRunToPlanEntry, AddSection, AddSharedStep, AddSuite, AddUser, AddVariable, AttachmentForCase, AttachmentForPlan, AttachmentForPlanEntry, AttachmentForRun, AttachmentForTest, Case, CaseField, CaseFilters, CaseHistory, CaseStatus, CaseType, Config, ConfigItem, CopyCasesToSection, CreatedAttachment, Dataset, DeleteCases, DeleteSharedStep, Group, Milestone, MilestoneFilters, MoveCasesToSection, MoveSection, Pagination, Plan, PlanEntry, PlanFilters, PlanItem, Priority, Project, ProjectFilters, Report, ReportUrls, Request, Response, Result, ResultField, ResultFilters, ResultForRunFilters, Role, Run, RunFilters, Section, SectionFilters, SharedStep, SharedStepFilters, SharedStepHistory, Status, Suite, Template, Test, TestFilters, UpdateCase, UpdateCases, UpdateConfig, UpdateConfigGroup, UpdateMilestone, UpdatePlan, UpdatePlanEntry, UpdateProject, UpdateRun, UpdateRunInPlanEntry, UpdateSection, UpdateSharedStep, UpdateSuite, User, UserFilters, Variable } from './payload';
 
 export * from './payload';
 export type { Request as Payload, Response as Model };
 
-type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...args: P) => R : never;
+type Signal = { signal: AbortSignal };
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 export default class TestRail {
   static Exception = TestRailException;
   private readonly ctx: TestRailCtx;
 
-  constructor(config?: { host: string; username: string; password: string, signal?: AbortSignal }) {
+  constructor(config?: Pick<TestRailCtx, 'username' | 'password' | 'signal' | 'implementations'> & { host: string; }) {
     this.ctx = {
       baseURL: (config?.host || '') + '/index.php?/api/v2/',
       // @ts-ignore - Backward compatibility
-      ...config?.user && { username: config.user },
-      ...config?.username && { username: config.username },
-      ...config?.password && { password: config.password },
-      ...config?.signal && { signal: config.signal }
+      ...(config?.user && { username: config.user }),
+      ...(config?.username && { username: config.username }),
+      ...(config?.password && { password: config.password }),
+      ...(config?.signal && { signal: config.signal }),
+      ...(config?.implementations && { implementations: config.implementations }),
     };
   }
 
-  addAttachmentToCase: OmitFirstArg<typeof methods['addAttachmentToCase']> = function (this: TestRail, ...args) {
-    return methods.addAttachmentToCase(this.ctx, ...args);
-  };
-
-  addAttachmentToPlan: OmitFirstArg<typeof methods['addAttachmentToPlan']> = function (this: TestRail, ...args) {
-    return methods.addAttachmentToPlan(this.ctx, ...args);
-  };
-
-  addAttachmentToPlanEntry: OmitFirstArg<typeof methods['addAttachmentToPlanEntry']> = function (this: TestRail, ...args) {
-    return methods.addAttachmentToPlanEntry(this.ctx, ...args);
-  };
-
-  addAttachmentToResult: OmitFirstArg<typeof methods['addAttachmentToResult']> = function (this: TestRail, ...args) {
-    return methods.addAttachmentToResult(this.ctx, ...args);
-  };
-
-  addAttachmentToRun: OmitFirstArg<typeof methods['addAttachmentToRun']> = function (this: TestRail, ...args) {
-    return methods.addAttachmentToRun(this.ctx, ...args);
-  };
-
-  getAttachmentsForCase: OmitFirstArg<typeof methods['getAttachmentsForCase']> = function (this: TestRail, ...args) {
-    return methods.getAttachmentsForCase(this.ctx, ...args);
-  };
-
-  getAttachmentsForPlan: OmitFirstArg<typeof methods['getAttachmentsForPlan']> = function (this: TestRail, ...args) {
-    return methods.getAttachmentsForPlan(this.ctx, ...args);
-  };
-
-  getAttachmentsForPlanEntry: OmitFirstArg<typeof methods['getAttachmentsForPlanEntry']> = function (this: TestRail, ...args) {
-    return methods.getAttachmentsForPlanEntry(this.ctx, ...args);
-  };
-
-  getAttachmentsForRun: OmitFirstArg<typeof methods['getAttachmentsForRun']> = function (this: TestRail, ...args) {
-    return methods.getAttachmentsForRun(this.ctx, ...args);
-  };
-
-  getAttachmentsForTest: OmitFirstArg<typeof methods['getAttachmentsForTest']> = function (this: TestRail, ...args) {
-    return methods.getAttachmentsForTest(this.ctx, ...args);
-  };
-
-  getAttachment: OmitFirstArg<typeof methods['getAttachment']> = function (this: TestRail, ...args) {
-    return methods.getAttachment(this.ctx, ...args);
-  };
-
-  deleteAttachment: OmitFirstArg<typeof methods['deleteAttachment']> = function (this: TestRail, ...args) {
-    return methods.deleteAttachment(this.ctx, ...args);
-  };
-
-  getBdd: OmitFirstArg<typeof methods['getBdd']> = function (this: TestRail, ...args) {
-    return methods.getBdd(this.ctx, ...args);
-  };
-
-  addBdd: OmitFirstArg<typeof methods['addBdd']> = function (this: TestRail, ...args) {
-    return methods.addBdd(this.ctx, ...args);
-  };
-
-  getCase: OmitFirstArg<typeof methods['getCase']> = function (this: TestRail, ...args) {
-    return methods.getCase(this.ctx, ...args);
-  };
-
-  getCases: OmitFirstArg<typeof methods['getCases']> = function (this: TestRail, ...args) {
-    return methods.getCases(this.ctx, ...args);
-  };
-
-  getHistoryForCase: OmitFirstArg<typeof methods['getHistoryForCase']> = function (this: TestRail, ...args) {
-    return methods.getHistoryForCase(this.ctx, ...args);
-  };
-
-  addCase: OmitFirstArg<typeof methods['addCase']> = function (this: TestRail, ...args) {
-    return methods.addCase(this.ctx, ...args);
-  };
-
-  copyCasesToSection: OmitFirstArg<typeof methods['copyCasesToSection']> = function (this: TestRail, ...args) {
-    return methods.copyCasesToSection(this.ctx, ...args);
-  };
-
-  updateCase: OmitFirstArg<typeof methods['updateCase']> = function (this: TestRail, ...args) {
-    return methods.updateCase(this.ctx, ...args);
-  };
-
-  updateCases: OmitFirstArg<typeof methods['updateCases']> = function (this: TestRail, ...args) {
-    return methods.updateCases(this.ctx, ...args);
-  };
-
-  moveCasesToSection: OmitFirstArg<typeof methods['moveCasesToSection']> = function (this: TestRail, ...args) {
-    return methods.moveCasesToSection(this.ctx, ...args);
-  };
-
-  deleteCase: OmitFirstArg<typeof methods['deleteCase']> = function (this: TestRail, ...args) {
-    return methods.deleteCase(this.ctx, ...args);
-  };
-
-  deleteCases: OmitFirstArg<typeof methods['deleteCases']> = function (this: TestRail, ...args) {
-    return methods.deleteCases(this.ctx, ...args);
-  };
-
-  getCaseFields: OmitFirstArg<typeof methods['getCaseFields']> = function (this: TestRail, ...args) {
-    return methods.getCaseFields(this.ctx, ...args);
-  };
-
-  addCaseField: OmitFirstArg<typeof methods['addCaseField']> = function (this: TestRail, ...args) {
-    return methods.addCaseField(this.ctx, ...args);
-  };
-
-  getCaseTypes: OmitFirstArg<typeof methods['getCaseTypes']> = function (this: TestRail, ...args) {
-    return methods.getCaseTypes(this.ctx, ...args);
-  };
-
-  getConfigs: OmitFirstArg<typeof methods['getConfigs']> = function (this: TestRail, ...args) {
-    return methods.getConfigs(this.ctx, ...args);
-  };
-
-  addConfigGroup: OmitFirstArg<typeof methods['addConfigGroup']> = function (this: TestRail, ...args) {
-    return methods.addConfigGroup(this.ctx, ...args);
-  };
-
-  addConfig: OmitFirstArg<typeof methods['addConfig']> = function (this: TestRail, ...args) {
-    return methods.addConfig(this.ctx, ...args);
-  };
-
-  updateConfigGroup: OmitFirstArg<typeof methods['updateConfigGroup']> = function (this: TestRail, ...args) {
-    return methods.updateConfigGroup(this.ctx, ...args);
-  };
-
-  updateConfig: OmitFirstArg<typeof methods['updateConfig']> = function (this: TestRail, ...args) {
-    return methods.updateConfig(this.ctx, ...args);
-  };
-
-  deleteConfigGroup: OmitFirstArg<typeof methods['deleteConfigGroup']> = function (this: TestRail, ...args) {
-    return methods.deleteConfigGroup(this.ctx, ...args);
-  };
-
-  deleteConfig: OmitFirstArg<typeof methods['deleteConfig']> = function (this: TestRail, ...args) {
-    return methods.deleteConfig(this.ctx, ...args);
-  };
-
-  getDataset: OmitFirstArg<typeof methods['getDataset']> = function (this: TestRail, ...args) {
-    return methods.getDataset(this.ctx, ...args);
-  };
-
-  getDatasets: OmitFirstArg<typeof methods['getDatasets']> = function (this: TestRail, ...args) {
-    return methods.getDatasets(this.ctx, ...args);
-  };
-
-  addDataset: OmitFirstArg<typeof methods['addDataset']> = function (this: TestRail, ...args) {
-    return methods.addDataset(this.ctx, ...args);
-  };
-
-  updateDataset: OmitFirstArg<typeof methods['updateDataset']> = function (this: TestRail, ...args) {
-    return methods.updateDataset(this.ctx, ...args);
-  };
-
-  deleteDataset: OmitFirstArg<typeof methods['deleteDataset']> = function (this: TestRail, ...args) {
-    return methods.deleteDataset(this.ctx, ...args);
-  };
-
-  getGroup: OmitFirstArg<typeof methods['getGroup']> = function (this: TestRail, ...args) {
-    return methods.getGroup(this.ctx, ...args);
-  };
-
-  getGroups: OmitFirstArg<typeof methods['getGroups']> = function (this: TestRail, ...args) {
-    return methods.getGroups(this.ctx, ...args);
-  };
-
-  addGroup: OmitFirstArg<typeof methods['addGroup']> = function (this: TestRail, ...args) {
-    return methods.addGroup(this.ctx, ...args);
-  };
-
-  updateGroup: OmitFirstArg<typeof methods['updateGroup']> = function (this: TestRail, ...args) {
-    return methods.updateGroup(this.ctx, ...args);
-  };
-
-  deleteGroup: OmitFirstArg<typeof methods['deleteGroup']> = function (this: TestRail, ...args) {
-    return methods.deleteGroup(this.ctx, ...args);
-  };
-
-  getMilestone: OmitFirstArg<typeof methods['getMilestone']> = function (this: TestRail, ...args) {
-    return methods.getMilestone(this.ctx, ...args);
-  };
-
-  getMilestones: OmitFirstArg<typeof methods['getMilestones']> = function (this: TestRail, ...args) {
-    return methods.getMilestones(this.ctx, ...args);
-  };
-
-  addMilestone: OmitFirstArg<typeof methods['addMilestone']> = function (this: TestRail, ...args) {
-    return methods.addMilestone(this.ctx, ...args);
-  };
-
-  updateMilestone: OmitFirstArg<typeof methods['updateMilestone']> = function (this: TestRail, ...args) {
-    return methods.updateMilestone(this.ctx, ...args);
-  };
-
-  deleteMilestone: OmitFirstArg<typeof methods['deleteMilestone']> = function (this: TestRail, ...args) {
-    return methods.deleteMilestone(this.ctx, ...args);
-  };
-
-  getPlan: OmitFirstArg<typeof methods['getPlan']> = function (this: TestRail, ...args) {
-    return methods.getPlan(this.ctx, ...args);
-  };
-
-  getPlans: OmitFirstArg<typeof methods['getPlans']> = function (this: TestRail, ...args) {
-    return methods.getPlans(this.ctx, ...args);
-  };
-
-  addPlan: OmitFirstArg<typeof methods['addPlan']> = function (this: TestRail, ...args) {
-    return methods.addPlan(this.ctx, ...args);
-  };
-
-  addPlanEntry: OmitFirstArg<typeof methods['addPlanEntry']> = function (this: TestRail, ...args) {
-    return methods.addPlanEntry(this.ctx, ...args);
-  };
-
-  addRunToPlanEntry: OmitFirstArg<typeof methods['addRunToPlanEntry']> = function (this: TestRail, ...args) {
-    return methods.addRunToPlanEntry(this.ctx, ...args);
-  };
-
-  updatePlan: OmitFirstArg<typeof methods['updatePlan']> = function (this: TestRail, ...args) {
-    return methods.updatePlan(this.ctx, ...args);
-  };
-
-  updatePlanEntry: OmitFirstArg<typeof methods['updatePlanEntry']> = function (this: TestRail, ...args) {
-    return methods.updatePlanEntry(this.ctx, ...args);
-  };
-
-  updateRunInPlanEntry: OmitFirstArg<typeof methods['updateRunInPlanEntry']> = function (this: TestRail, ...args) {
-    return methods.updateRunInPlanEntry(this.ctx, ...args);
-  };
-
-  closePlan: OmitFirstArg<typeof methods['closePlan']> = function (this: TestRail, ...args) {
-    return methods.closePlan(this.ctx, ...args);
-  };
-
-  deletePlan: OmitFirstArg<typeof methods['deletePlan']> = function (this: TestRail, ...args) {
-    return methods.deletePlan(this.ctx, ...args);
-  };
-
-  deletePlanEntry: OmitFirstArg<typeof methods['deletePlanEntry']> = function (this: TestRail, ...args) {
-    return methods.deletePlanEntry(this.ctx, ...args);
-  };
-
-  deleteRunFromPlanEntry: OmitFirstArg<typeof methods['deleteRunFromPlanEntry']> = function (this: TestRail, ...args) {
-    return methods.deleteRunFromPlanEntry(this.ctx, ...args);
-  };
-
-  getPriorities: OmitFirstArg<typeof methods['getPriorities']> = function (this: TestRail, ...args) {
-    return methods.getPriorities(this.ctx, ...args);
-  };
-
-  getProject: OmitFirstArg<typeof methods['getProject']> = function (this: TestRail, ...args) {
-    return methods.getProject(this.ctx, ...args);
-  };
-
-  getProjects: OmitFirstArg<typeof methods['getProjects']> = function (this: TestRail, ...args) {
-    return methods.getProjects(this.ctx, ...args);
-  };
-
-  addProject: OmitFirstArg<typeof methods['addProject']> = function (this: TestRail, ...args) {
-    return methods.addProject(this.ctx, ...args);
-  };
-
-  updateProject: OmitFirstArg<typeof methods['updateProject']> = function (this: TestRail, ...args) {
-    return methods.updateProject(this.ctx, ...args);
-  };
-
-  deleteProject: OmitFirstArg<typeof methods['deleteProject']> = function (this: TestRail, ...args) {
-    return methods.deleteProject(this.ctx, ...args);
-  };
-
-  getReports: OmitFirstArg<typeof methods['getReports']> = function (this: TestRail, ...args) {
-    return methods.getReports(this.ctx, ...args);
-  };
-
-  runReport: OmitFirstArg<typeof methods['runReport']> = function (this: TestRail, ...args) {
-    return methods.runReport(this.ctx, ...args);
-  };
-
-  getResults: OmitFirstArg<typeof methods['getResults']> = function (this: TestRail, ...args) {
-    return methods.getResults(this.ctx, ...args);
-  };
-
-  getResultsForCase: OmitFirstArg<typeof methods['getResultsForCase']> = function (this: TestRail, ...args) {
-    return methods.getResultsForCase(this.ctx, ...args);
-  };
-
-  getResultsForRun: OmitFirstArg<typeof methods['getResultsForRun']> = function (this: TestRail, ...args) {
-    return methods.getResultsForRun(this.ctx, ...args);
-  };
-
-  addResult: OmitFirstArg<typeof methods['addResult']> = function (this: TestRail, ...args) {
-    return methods.addResult(this.ctx, ...args);
-  };
-
-  addResultForCase: OmitFirstArg<typeof methods['addResultForCase']> = function (this: TestRail, ...args) {
-    return methods.addResultForCase(this.ctx, ...args);
-  };
-
-  addResults: OmitFirstArg<typeof methods['addResults']> = function (this: TestRail, ...args) {
-    return methods.addResults(this.ctx, ...args);
-  };
-
-  addResultsForCases: OmitFirstArg<typeof methods['addResultsForCases']> = function (this: TestRail, ...args) {
-    return methods.addResultsForCases(this.ctx, ...args);
-  };
-
-  getResultFields: OmitFirstArg<typeof methods['getResultFields']> = function (this: TestRail, ...args) {
-    return methods.getResultFields(this.ctx, ...args);
-  };
-
-  getRoles: OmitFirstArg<typeof methods['getRoles']> = function (this: TestRail, ...args) {
-    return methods.getRoles(this.ctx, ...args);
-  };
-
-  getRun: OmitFirstArg<typeof methods['getRun']> = function (this: TestRail, ...args) {
-    return methods.getRun(this.ctx, ...args);
-  };
-
-  getRuns: OmitFirstArg<typeof methods['getRuns']> = function (this: TestRail, ...args) {
-    return methods.getRuns(this.ctx, ...args);
-  };
-
-  addRun: OmitFirstArg<typeof methods['addRun']> = function (this: TestRail, ...args) {
-    return methods.addRun(this.ctx, ...args);
-  };
-
-  updateRun: OmitFirstArg<typeof methods['updateRun']> = function (this: TestRail, ...args) {
-    return methods.updateRun(this.ctx, ...args);
-  };
-
-  closeRun: OmitFirstArg<typeof methods['closeRun']> = function (this: TestRail, ...args) {
-    return methods.closeRun(this.ctx, ...args);
-  };
-
-  deleteRun: OmitFirstArg<typeof methods['deleteRun']> = function (this: TestRail, ...args) {
-    return methods.deleteRun(this.ctx, ...args);
-  };
-
-  getSection: OmitFirstArg<typeof methods['getSection']> = function (this: TestRail, ...args) {
-    return methods.getSection(this.ctx, ...args);
-  };
-
-  getSections: OmitFirstArg<typeof methods['getSections']> = function (this: TestRail, ...args) {
-    return methods.getSections(this.ctx, ...args);
-  };
-
-  addSection: OmitFirstArg<typeof methods['addSection']> = function (this: TestRail, ...args) {
-    return methods.addSection(this.ctx, ...args);
-  };
-
-  moveSection: OmitFirstArg<typeof methods['moveSection']> = function (this: TestRail, ...args) {
-    return methods.moveSection(this.ctx, ...args);
-  };
-
-  updateSection: OmitFirstArg<typeof methods['updateSection']> = function (this: TestRail, ...args) {
-    return methods.updateSection(this.ctx, ...args);
-  };
-
-  deleteSection: OmitFirstArg<typeof methods['deleteSection']> = function (this: TestRail, ...args) {
-    return methods.deleteSection(this.ctx, ...args);
-  };
-
-  getSharedStep: OmitFirstArg<typeof methods['getSharedStep']> = function (this: TestRail, ...args) {
-    return methods.getSharedStep(this.ctx, ...args);
-  };
-
-  getSharedSteps: OmitFirstArg<typeof methods['getSharedSteps']> = function (this: TestRail, ...args) {
-    return methods.getSharedSteps(this.ctx, ...args);
-  };
-
-  getSharedStepHistory: OmitFirstArg<typeof methods['getSharedStepHistory']> = function (this: TestRail, ...args) {
-    return methods.getSharedStepHistory(this.ctx, ...args);
-  };
-
-  addSharedStep: OmitFirstArg<typeof methods['addSharedStep']> = function (this: TestRail, ...args) {
-    return methods.addSharedStep(this.ctx, ...args);
-  };
-
-  updateSharedStep: OmitFirstArg<typeof methods['updateSharedStep']> = function (this: TestRail, ...args) {
-    return methods.updateSharedStep(this.ctx, ...args);
-  };
-
-  deleteSharedStep: OmitFirstArg<typeof methods['deleteSharedStep']> = function (this: TestRail, ...args) {
-    return methods.deleteSharedStep(this.ctx, ...args);
-  };
-
-  getStatuses: OmitFirstArg<typeof methods['getStatuses']> = function (this: TestRail, ...args) {
-    return methods.getStatuses(this.ctx, ...args);
-  };
-
-  getCaseStatuses: OmitFirstArg<typeof methods['getCaseStatuses']> = function (this: TestRail, ...args) {
-    return methods.getCaseStatuses(this.ctx, ...args);
-  };
-
-  getSuite: OmitFirstArg<typeof methods['getSuite']> = function (this: TestRail, ...args) {
-    return methods.getSuite(this.ctx, ...args);
-  };
-
-  getSuites: OmitFirstArg<typeof methods['getSuites']> = function (this: TestRail, ...args) {
-    return methods.getSuites(this.ctx, ...args);
-  };
-
-  addSuite: OmitFirstArg<typeof methods['addSuite']> = function (this: TestRail, ...args) {
-    return methods.addSuite(this.ctx, ...args);
-  };
-
-  updateSuite: OmitFirstArg<typeof methods['updateSuite']> = function (this: TestRail, ...args) {
-    return methods.updateSuite(this.ctx, ...args);
-  };
-
-  deleteSuite: OmitFirstArg<typeof methods['deleteSuite']> = function (this: TestRail, ...args) {
-    return methods.deleteSuite(this.ctx, ...args);
-  };
-
-  getTemplates: OmitFirstArg<typeof methods['getTemplates']> = function (this: TestRail, ...args) {
-    return methods.getTemplates(this.ctx, ...args);
-  };
-
-  getTest: OmitFirstArg<typeof methods['getTest']> = function (this: TestRail, ...args) {
-    return methods.getTest(this.ctx, ...args);
-  };
-
-  getTests: OmitFirstArg<typeof methods['getTests']> = function (this: TestRail, ...args) {
-    return methods.getTests(this.ctx, ...args);
-  };
-
-  getUser: OmitFirstArg<typeof methods['getUser']> = function (this: TestRail, ...args) {
-    return methods.getUser(this.ctx, ...args);
-  };
-
-  getCurrentUser: OmitFirstArg<typeof methods['getCurrentUser']> = function (this: TestRail, ...args) {
-    return methods.getCurrentUser(this.ctx, ...args);
-  };
-
-  getUserByEmail: OmitFirstArg<typeof methods['getUserByEmail']> = function (this: TestRail, ...args) {
-    return methods.getUserByEmail(this.ctx, ...args);
-  };
-
-  getUsers: OmitFirstArg<typeof methods['getUsers']> = function (this: TestRail, ...args) {
-    return methods.getUsers(this.ctx, ...args);
-  };
-
-  addUser: OmitFirstArg<typeof methods['addUser']> = function (this: TestRail, ...args) {
-    return methods.addUser(this.ctx, ...args);
-  };
-
-  updateUser: OmitFirstArg<typeof methods['updateUser']> = function (this: TestRail, ...args) {
-    return methods.updateUser(this.ctx, ...args);
-  };
-
-  getVariables: OmitFirstArg<typeof methods['getVariables']> = function (this: TestRail, ...args) {
-    return methods.getVariables(this.ctx, ...args);
-  };
-
-  addVariable: OmitFirstArg<typeof methods['addVariable']> = function (this: TestRail, ...args) {
-    return methods.addVariable(this.ctx, ...args);
-  };
-
-  updateVariable: OmitFirstArg<typeof methods['updateVariable']> = function (this: TestRail, ...args) {
-    return methods.updateVariable(this.ctx, ...args);
-  };
-
-  deleteVariable: OmitFirstArg<typeof methods['deleteVariable']> = function (this: TestRail, ...args) {
-    return methods.deleteVariable(this.ctx, ...args);
-  };
+  addAttachmentToCase(caseId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
+    return methods.addAttachmentToCase(this.getCtx(options), caseId, payload);
+  }
+
+  addAttachmentToPlan(planId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
+    return methods.addAttachmentToPlan(this.getCtx(options), planId, payload);
+  }
+
+  addAttachmentToPlanEntry(planId: number, entryId: string, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
+    return methods.addAttachmentToPlanEntry(this.getCtx(options), planId, entryId, payload);
+  }
+
+  addAttachmentToResult(resultId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
+    return methods.addAttachmentToResult(this.getCtx(options), resultId, payload);
+  }
+
+  addAttachmentToRun(runId: number, payload: AddAttachment, options?: Signal): Promise<CreatedAttachment> {
+    return methods.addAttachmentToRun(this.getCtx(options), runId, payload);
+  }
+
+  getAttachmentsForCase(caseId: number, filters?: Pagination, options?: Signal): Promise<AttachmentForCase[]> {
+    return methods.getAttachmentsForCase(this.getCtx(options), caseId, filters);
+  }
+
+  getAttachmentsForPlan(planId: number, filters?: Pagination, options?: Signal): Promise<AttachmentForPlan[]> {
+    return methods.getAttachmentsForPlan(this.getCtx(options), planId, filters);
+  }
+
+  getAttachmentsForPlanEntry(planId: number, entryId: string, options?: Signal): Promise<AttachmentForPlanEntry[]> {
+    return methods.getAttachmentsForPlanEntry(this.getCtx(options), planId, entryId);
+  }
+
+  getAttachmentsForRun(runId: number, filters?: Pagination, options?: Signal): Promise<AttachmentForRun[]> {
+    return methods.getAttachmentsForRun(this.getCtx(options), runId, filters);
+  }
+
+  getAttachmentsForTest(testId: number, options?: Signal): Promise<AttachmentForTest[]> {
+    return methods.getAttachmentsForTest(this.getCtx(options), testId);
+  }
+
+  getAttachment(attachmentId: string, options?: Signal): Promise<Blob> {
+    return methods.getAttachment(this.getCtx(options), attachmentId);
+  }
+
+  deleteAttachment(attachmentId: string, options?: Signal): Promise<void> {
+    return methods.deleteAttachment(this.getCtx(options), attachmentId);
+  }
+
+  getBdd(caseId: number, options?: Signal): Promise<Blob> {
+    return methods.getBdd(this.getCtx(options), caseId);
+  }
+
+  addBdd(sectionId: number, payload: AddAttachment, options?: Signal): Promise<Case> {
+    return methods.addBdd(this.getCtx(options), sectionId, payload);
+  }
+
+  getCase(caseId: number, options?: Signal): Promise<Case> {
+    return methods.getCase(this.getCtx(options), caseId);
+  }
+
+  getCases(projectId: number, filters?: CaseFilters, options?: Signal): Promise<Case[]> {
+    return methods.getCases(this.getCtx(options), projectId, filters);
+  }
+
+  getHistoryForCase(caseId: number, filters?: Pagination, options?: Signal): Promise<CaseHistory[]> {
+    return methods.getHistoryForCase(this.getCtx(options), caseId, filters);
+  }
+
+  addCase(sectionId: number, payload: AddCase, options?: Signal): Promise<Case> {
+    return methods.addCase(this.getCtx(options), sectionId, payload);
+  }
+
+  copyCasesToSection(sectionId: number, payload: CopyCasesToSection, options?: Signal): Promise<void> {
+    return methods.copyCasesToSection(this.getCtx(options), sectionId, payload);
+  }
+
+  updateCase(caseId: number, payload: UpdateCase, options?: Signal): Promise<Case> {
+    return methods.updateCase(this.getCtx(options), caseId, payload);
+  }
+
+  updateCases(suiteId: number, payload: UpdateCases, options?: Signal): Promise<void> {
+    return methods.updateCases(this.getCtx(options), suiteId, payload);
+  }
+
+  moveCasesToSection(sectionId: number, payload: MoveCasesToSection, options?: Signal): Promise<void> {
+    return methods.moveCasesToSection(this.getCtx(options), sectionId, payload);
+  }
+
+  deleteCase(caseId: number, options?: Signal): Promise<void> {
+    return methods.deleteCase(this.getCtx(options), caseId);
+  }
+
+  deleteCases(suiteId: number, payload: DeleteCases, options?: Signal): Promise<void> {
+    return methods.deleteCases(this.getCtx(options), suiteId, payload);
+  }
+
+  getCaseFields(options?: Signal): Promise<CaseField[]> {
+    return methods.getCaseFields(this.getCtx(options));
+  }
+
+  addCaseField(payload: AddCaseField, options?: Signal): Promise<CaseField> {
+    return methods.addCaseField(this.getCtx(options), payload);
+  }
+
+  getCaseTypes(options?: Signal): Promise<CaseType[]> {
+    return methods.getCaseTypes(this.getCtx(options));
+  }
+
+  getConfigs(projectId: number, options?: Signal): Promise<Config[]> {
+    return methods.getConfigs(this.getCtx(options), projectId);
+  }
+
+  addConfigGroup(projectId: number, payload: AddConfigGroup, options?: Signal): Promise<Config> {
+    return methods.addConfigGroup(this.getCtx(options), projectId, payload);
+  }
+
+  addConfig(configGroupId: number, payload: AddConfig, options?: Signal): Promise<ConfigItem> {
+    return methods.addConfig(this.getCtx(options), configGroupId, payload);
+  }
+
+  updateConfigGroup(configGroupId: number, payload: UpdateConfigGroup, options?: Signal): Promise<Config> {
+    return methods.updateConfigGroup(this.getCtx(options), configGroupId, payload);
+  }
+
+  updateConfig(configId: number, payload: UpdateConfig, options?: Signal): Promise<ConfigItem> {
+    return methods.updateConfig(this.getCtx(options), configId, payload);
+  }
+
+  deleteConfigGroup(configGroupId: number, options?: Signal): Promise<void> {
+    return methods.deleteConfigGroup(this.getCtx(options), configGroupId);
+  }
+
+  deleteConfig(configId: number, options?: Signal): Promise<void> {
+    return methods.deleteConfig(this.getCtx(options), configId);
+  }
+
+  getDataset(datasetId: number, options?: Signal): Promise<Dataset> {
+    return methods.getDataset(this.getCtx(options), datasetId);
+  }
+
+  getDatasets(projectId: number, filters?: Pagination, options?: Signal): Promise<Dataset[]> {
+    return methods.getDatasets(this.getCtx(options), projectId, filters);
+  }
+
+  addDataset(projectId: number, payload: AddDataset, options?: Signal): Promise<Group> {
+    return methods.addDataset(this.getCtx(options), projectId, payload);
+  }
+
+  updateDataset(datasetId: number, payload: AddDataset, options?: Signal): Promise<Group> {
+    return methods.updateDataset(this.getCtx(options), datasetId, payload);
+  }
+
+  deleteDataset(datasetId: number, options?: Signal): Promise<void> {
+    return methods.deleteDataset(this.getCtx(options), datasetId);
+  }
+
+  getGroup(groupId: number, options?: Signal): Promise<Group> {
+    return methods.getGroup(this.getCtx(options), groupId);
+  }
+
+  getGroups(filters?: Pagination, options?: Signal): Promise<Group[]> {
+    return methods.getGroups(this.getCtx(options), filters);
+  }
+
+  addGroup(payload: AddGroup, options?: Signal): Promise<Group> {
+    return methods.addGroup(this.getCtx(options), payload);
+  }
+
+  updateGroup(groupId: number, payload: AddGroup, options?: Signal): Promise<Group> {
+    return methods.updateGroup(this.getCtx(options), groupId, payload);
+  }
+
+  deleteGroup(groupId: number, options?: Signal): Promise<void> {
+    return methods.deleteGroup(this.getCtx(options), groupId);
+  }
+
+  getMilestone(milestoneId: number, options?: Signal): Promise<Milestone> {
+    return methods.getMilestone(this.getCtx(options), milestoneId);
+  }
+
+  getMilestones(projectId: number, filters?: MilestoneFilters, options?: Signal): Promise<Milestone[]> {
+    return methods.getMilestones(this.getCtx(options), projectId, filters);
+  }
+
+  addMilestone(projectId: number, payload: AddMilestone, options?: Signal): Promise<Milestone> {
+    return methods.addMilestone(this.getCtx(options), projectId, payload);
+  }
+
+  updateMilestone(milestoneId: number, payload: UpdateMilestone, options?: Signal): Promise<Milestone> {
+    return methods.updateMilestone(this.getCtx(options), milestoneId, payload);
+  }
+
+  deleteMilestone(milestoneId: number, options?: Signal): Promise<void> {
+    return methods.deleteMilestone(this.getCtx(options), milestoneId);
+  }
+
+  getPlan(planId: number, options?: Signal): Promise<Plan> {
+    return methods.getPlan(this.getCtx(options), planId);
+  }
+
+  getPlans(projectId: number, filters?: PlanFilters, options?: Signal): Promise<PlanItem[]> {
+    return methods.getPlans(this.getCtx(options), projectId, filters);
+  }
+
+  addPlan(projectId: number, payload: AddPlan, options?: Signal): Promise<Plan> {
+    return methods.addPlan(this.getCtx(options), projectId, payload);
+  }
+
+  addPlanEntry(planId: number, payload: AddPlanEntry, options?: Signal): Promise<PlanEntry> {
+    return methods.addPlanEntry(this.getCtx(options), planId, payload);
+  }
+
+  addRunToPlanEntry(planId: number, entryId: string, payload: AddRunToPlanEntry, options?: Signal): Promise<PlanEntry> {
+    return methods.addRunToPlanEntry(this.getCtx(options), planId, entryId, payload);
+  }
+
+  updatePlan(planId: number, payload: UpdatePlan, options?: Signal): Promise<Plan> {
+    return methods.updatePlan(this.getCtx(options), planId, payload);
+  }
+
+  updatePlanEntry(planId: number, entryId: string, payload: UpdatePlanEntry, options?: Signal): Promise<PlanEntry> {
+    return methods.updatePlanEntry(this.getCtx(options), planId, entryId, payload);
+  }
+
+  updateRunInPlanEntry(runId: number, payload: UpdateRunInPlanEntry, options?: Signal): Promise<PlanEntry> {
+    return methods.updateRunInPlanEntry(this.getCtx(options), runId, payload);
+  }
+
+  closePlan(planId: number, options?: Signal): Promise<Plan> {
+    return methods.closePlan(this.getCtx(options), planId);
+  }
+
+  deletePlan(planId: number, options?: Signal): Promise<void> {
+    return methods.deletePlan(this.getCtx(options), planId);
+  }
+
+  deletePlanEntry(planId: number, entryId: string, options?: Signal): Promise<void> {
+    return methods.deletePlanEntry(this.getCtx(options), planId, entryId);
+  }
+
+  deleteRunFromPlanEntry(runId: number, options?: Signal): Promise<void> {
+    return methods.deleteRunFromPlanEntry(this.getCtx(options), runId);
+  }
+
+  getPriorities(options?: Signal): Promise<Priority[]> {
+    return methods.getPriorities(this.getCtx(options));
+  }
+
+  getProject(projectId: number, options?: Signal): Promise<Project> {
+    return methods.getProject(this.getCtx(options), projectId);
+  }
+
+  getProjects(filters?: ProjectFilters, options?: Signal): Promise<Project[]> {
+    return methods.getProjects(this.getCtx(options), filters);
+  }
+
+  addProject(payload: AddProject, options?: Signal): Promise<Project> {
+    return methods.addProject(this.getCtx(options), payload);
+  }
+
+  updateProject(projectId: number, payload: UpdateProject, options?: Signal): Promise<Project> {
+    return methods.updateProject(this.getCtx(options), projectId, payload);
+  }
+
+  deleteProject(projectId: number, options?: Signal): Promise<void> {
+    return methods.deleteProject(this.getCtx(options), projectId);
+  }
+
+  getReports(projectId: number, options?: Signal): Promise<Report[]> {
+    return methods.getReports(this.getCtx(options), projectId);
+  }
+
+  runReport(reportTemplateId: number, options?: Signal): Promise<ReportUrls> {
+    return methods.runReport(this.getCtx(options), reportTemplateId);
+  }
+
+  getResults(testId: number, filters?: ResultFilters, options?: Signal): Promise<Result[]> {
+    return methods.getResults(this.getCtx(options), testId, filters);
+  }
+
+  getResultsForCase(runId: number, caseId: number, filters?: ResultFilters, options?: Signal): Promise<Result[]> {
+    return methods.getResultsForCase(this.getCtx(options), runId, caseId, filters);
+  }
+
+  getResultsForRun(runId: number, filters?: ResultForRunFilters, options?: Signal): Promise<Result[]> {
+    return methods.getResultsForRun(this.getCtx(options), runId, filters);
+  }
+
+  addResult(testId: number, payload: AddResult, options?: Signal): Promise<Result> {
+    return methods.addResult(this.getCtx(options), testId, payload);
+  }
+
+  addResultForCase(runId: number, caseId: number, payload: AddResult, options?: Signal): Promise<Result> {
+    return methods.addResultForCase(this.getCtx(options), runId, caseId, payload);
+  }
+
+  addResults(runId: number, payload: AddResults, options?: Signal): Promise<Result[]> {
+    return methods.addResults(this.getCtx(options), runId, payload);
+  }
+
+  addResultsForCases(runId: number, payload: AddResultsForCases, options?: Signal): Promise<Result[]> {
+    return methods.addResultsForCases(this.getCtx(options), runId, payload);
+  }
+
+  getResultFields(options?: Signal): Promise<ResultField[]> {
+    return methods.getResultFields(this.getCtx(options));
+  }
+
+  getRoles(filters?: Pagination, options?: Signal): Promise<Role[]> {
+    return methods.getRoles(this.getCtx(options), filters);
+  }
+
+  getRun(runId: number, options?: Signal): Promise<Run> {
+    return methods.getRun(this.getCtx(options), runId);
+  }
+
+  getRuns(projectId: number, filters?: RunFilters, options?: Signal): Promise<Run[]> {
+    return methods.getRuns(this.getCtx(options), projectId, filters);
+  }
+
+  addRun(projectId: number, payload: AddRun, options?: Signal): Promise<Run> {
+    return methods.addRun(this.getCtx(options), projectId, payload);
+  }
+
+  updateRun(runId: number, payload: UpdateRun, options?: Signal): Promise<Run> {
+    return methods.updateRun(this.getCtx(options), runId, payload);
+  }
+
+  closeRun(runId: number, options?: Signal): Promise<Run> {
+    return methods.closeRun(this.getCtx(options), runId);
+  }
+
+  deleteRun(runId: number, options?: Signal): Promise<void> {
+    return methods.deleteRun(this.getCtx(options), runId);
+  }
+
+  getSection(sectionId: number, options?: Signal): Promise<Section> {
+    return methods.getSection(this.getCtx(options), sectionId);
+  }
+
+  getSections(projectId: number, filters?: SectionFilters, options?: Signal): Promise<Section[]> {
+    return methods.getSections(this.getCtx(options), projectId, filters);
+  }
+
+  addSection(projectId: number, payload: AddSection, options?: Signal): Promise<Section> {
+    return methods.addSection(this.getCtx(options), projectId, payload);
+  }
+
+  moveSection(sectionId: number, payload: MoveSection, options?: Signal): Promise<Section> {
+    return methods.moveSection(this.getCtx(options), sectionId, payload);
+  }
+
+  updateSection(sectionId: number, payload: UpdateSection, options?: Signal): Promise<Section> {
+    return methods.updateSection(this.getCtx(options), sectionId, payload);
+  }
+
+  deleteSection(sectionId: number, options?: Signal): Promise<void> {
+    return methods.deleteSection(this.getCtx(options), sectionId);
+  }
+
+  getSharedStep(stepId: number, options?: Signal): Promise<SharedStep> {
+    return methods.getSharedStep(this.getCtx(options), stepId);
+  }
+
+  getSharedSteps(projectId: number, filters?: SharedStepFilters, options?: Signal): Promise<SharedStep[]> {
+    return methods.getSharedSteps(this.getCtx(options), projectId, filters);
+  }
+
+  getSharedStepHistory(stepId: number, filters?: Pagination, options?: Signal): Promise<SharedStepHistory[]> {
+    return methods.getSharedStepHistory(this.getCtx(options), stepId, filters);
+  }
+
+  addSharedStep(projectId: number, payload: AddSharedStep, options?: Signal): Promise<SharedStep> {
+    return methods.addSharedStep(this.getCtx(options), projectId, payload);
+  }
+
+  updateSharedStep(stepId: number, payload: UpdateSharedStep, options?: Signal): Promise<SharedStep> {
+    return methods.updateSharedStep(this.getCtx(options), stepId, payload);
+  }
+
+  deleteSharedStep(stepId: number, payload?: DeleteSharedStep, options?: Signal): Promise<void> {
+    return methods.deleteSharedStep(this.getCtx(options), stepId, payload);
+  }
+
+  getStatuses(options?: Signal): Promise<Status[]> {
+    return methods.getStatuses(this.getCtx(options));
+  }
+
+  getCaseStatuses(filters?: Pagination, options?: Signal): Promise<CaseStatus[]> {
+    return methods.getCaseStatuses(this.getCtx(options), filters);
+  }
+
+  getSuite(suiteId: number, options?: Signal): Promise<Suite> {
+    return methods.getSuite(this.getCtx(options), suiteId);
+  }
+
+  getSuites(projectId: number, options?: Signal): Promise<Suite[]> {
+    return methods.getSuites(this.getCtx(options), projectId);
+  }
+
+  addSuite(projectId: number, payload: AddSuite, options?: Signal): Promise<Suite> {
+    return methods.addSuite(this.getCtx(options), projectId, payload);
+  }
+
+  updateSuite(suiteId: number, payload: UpdateSuite, options?: Signal): Promise<Suite> {
+    return methods.updateSuite(this.getCtx(options), suiteId, payload);
+  }
+
+  deleteSuite(suiteId: number, options?: Signal): Promise<void> {
+    return methods.deleteSuite(this.getCtx(options), suiteId);
+  }
+
+  getTemplates(projectId: number, options?: Signal): Promise<Template[]> {
+    return methods.getTemplates(this.getCtx(options), projectId);
+  }
+
+  getTest(testId: number, options?: Signal): Promise<Test> {
+    return methods.getTest(this.getCtx(options), testId);
+  }
+
+  getTests(runId: number, filters?: TestFilters, options?: Signal): Promise<Test[]> {
+    return methods.getTests(this.getCtx(options), runId, filters);
+  }
+
+  getUser(userId: number, options?: Signal): Promise<User> {
+    return methods.getUser(this.getCtx(options), userId);
+  }
+
+  getCurrentUser(options?: Signal): Promise<User> {
+    return methods.getCurrentUser(this.getCtx(options));
+  }
+
+  getUserByEmail(email: string, options?: Signal): Promise<User> {
+    return methods.getUserByEmail(this.getCtx(options), email);
+  }
+
+  getUsers(filters?: UserFilters, options?: Signal): Promise<User[]> {
+    return methods.getUsers(this.getCtx(options), filters);
+  }
+
+  addUser(payload: AddUser, options?: Signal): Promise<User> {
+    return methods.addUser(this.getCtx(options), payload);
+  }
+
+  updateUser(userId: number, payload: AddUser, options?: Signal): Promise<User> {
+    return methods.updateUser(this.getCtx(options), userId, payload);
+  }
+
+  getVariables(projectId: number, filters?: Pagination, options?: Signal): Promise<Variable[]> {
+    return methods.getVariables(this.getCtx(options), projectId, filters);
+  }
+
+  addVariable(projectId: number, payload: AddVariable, options?: Signal): Promise<Variable> {
+    return methods.addVariable(this.getCtx(options), projectId, payload);
+  }
+
+  updateVariable(variableId: number, payload: AddVariable, options?: Signal): Promise<Variable> {
+    return methods.updateVariable(this.getCtx(options), variableId, payload);
+  }
+
+  deleteVariable(variableId: number, options?: Signal): Promise<void> {
+    return methods.deleteVariable(this.getCtx(options), variableId);
+  }
+
+  private getCtx(options?: Signal): TestRailCtx {
+    const ctx: Mutable<TestRailCtx> = Object.create(this.ctx);
+
+    if (options?.signal) {
+      if (ctx.signal) {
+        // @ts-ignore - intentionally throws "ReferrerError" if "AbortController" is not available
+        const controller = new (ctx.implementations?.AbortController || AbortController)();
+
+        if (ctx.signal.aborted) {
+          controller.abort(ctx.signal.reason);
+        } else if (options.signal.aborted) {
+          controller.abort(options.signal.reason);
+        }
+
+        if (controller.signal.aborted) {
+          throw controller.signal.reason;
+        }
+
+        ctx.signal.addEventListener('abort', onAbort);
+        options.signal.addEventListener('abort', onAbort);
+
+        function onAbort() {
+          ctx.signal?.removeEventListener('abort', onAbort);
+          options?.signal.removeEventListener('abort', onAbort);
+          controller.abort(ctx.signal?.reason || options?.signal.reason);
+        }
+
+        ctx.signal = controller.signal;
+      } else {
+        ctx.signal = options.signal;
+      }
+    }
+
+    return ctx;
+  }
 }

--- a/src/TestRailCtx.ts
+++ b/src/TestRailCtx.ts
@@ -3,4 +3,10 @@ export type TestRailCtx = {
   readonly username?: string;
   readonly password?: string;
   readonly signal?: AbortSignal;
+  readonly implementations?: {
+    readonly AbortController?: any
+    readonly Blob?: any;
+    readonly fetch?: any;
+    readonly FormData?: any;
+  };
 };


### PR DESCRIPTION
Added ability to set AbortSignal on individual method (fixes: #70).

```typescript
const abortController = new AbortController();

const api = new TestRail({
  host: '...',
  username: '...',
  password: '...',

  // aborts all pending instance requests and prevents future
  signal: abortController.signal,
});

// will be aborted when the first signal is interrupted (either `instance` or `method` signal)
const projects = await api.getProjects(
  {
    is_completed: false
  },
  {
    // aborts specific method
    signal: AbortSignal.timeout(10000),
  }
);

// abort all requests made with the current `api` instance
abortController.abort();
```

To be able to use this feature in an older js environment without polyfills, the ability to provide implementations via the constructor has been added too.

```typescript
const api = new TestRail({
  /* standard parameters (haven't changed) */,

  // overrides the API implementation to be used (make possible to use ponyfills)
  implementations: { AbortController, Blob, fetch, FormData }
});
```
