### PR TITLE
fix: support for `skipLibCheck` in `tsconfig.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "unpkg": "dist/TestRail.umd.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "rollup --bundleConfigAsCjs -c",
+    "build": "rollup --bundleConfigAsCjs -c && replace-in-file '/(\\.\\.\\/)+src/g' '../src' 'dist/*.map' --isRegex",
     "test": "mocha -A -r ts-node/register test/**/*.ts"
   },
   "engines": {
@@ -49,6 +49,7 @@
     "intermock": "^0.2.5",
     "mocha": "^10.2.0",
     "nock": "^13.3.1",
+    "replace-in-file": "^6.3.5",
     "rollup": "^3.21.6",
     "rollup-plugin-dts": "^5.3.0",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "src",
     "dist"
   ],
-  "types": "src/types.d.ts",
+  "types": "dist/TestRail.d.ts",
   "main": "dist/TestRail.node.js",
   "module": "dist/TestRail.node.mjs",
   "browser": "dist/TestRail.browser.mjs",
@@ -37,7 +37,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-terser": "^0.4.1",
     "@rollup/plugin-typescript": "^11.1.0",
-    "@types/chai": "^4.3.4",
+    "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
     "@types/deasync": "^0.1.2",
     "@types/glob": "^8.1.0",
@@ -45,11 +45,12 @@
     "@types/node": "*",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
-    "glob": "^10.1.0",
+    "glob": "^10.2.3",
     "intermock": "^0.2.5",
     "mocha": "^10.2.0",
-    "nock": "^13.3.0",
-    "rollup": "^3.20.4",
+    "nock": "^13.3.1",
+    "rollup": "^3.21.6",
+    "rollup-plugin-dts": "^5.3.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,60 +1,82 @@
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
+import dts from "rollup-plugin-dts";
 import pkg from './package.json';
 
-export default {
-  input: 'src/TestRail.ts',
-  external: [],
-  output: [
-    {
-      file: pkg.browser,
-      format: 'es',
-      exports: 'default',
-      sourcemap: true,
-    },
-    {
-      file: pkg.jsdelivr,
-      format: 'umd',
-      exports: 'default',
-      sourcemap: true,
-      name: 'TestRail',
-    },
-    {
-      file: pkg.main,
+export default [
+  {
+    input: 'src/TestRail.ts',
+    external: ['stream'],
+    output: {
+      file: 'dist/TestRail.d.ts',
       format: 'cjs',
-      exports: 'default',
-      strict: false,
-      sourcemap: true,
-      banner: `'use strict';\n`
-        + `const http = require('http');\n`
-        + `const https = require('https');\n`
-        + `const nodeFetch = require('node-fetch');\n`
-        + `const FormData = require('form-data');\n\n`
-        + `const options = { keepAlive: true };\n`
-        + `const httpAgent = new http.Agent(options);\n`
-        + `const httpsAgent = new https.Agent(options);\n`
-        + `const agent = (url) => url.protocol === 'http:' ? httpAgent : httpsAgent;\n`
-        + `const fetch = (url, init) => nodeFetch(url, { agent, ...init });\n`,
+      footer: '\n// @ts-ignore\nexport = TestRail;',
     },
-    {
-      file: pkg.module,
-      format: 'es',
-      exports: 'default',
-      sourcemap: true,
-      banner: ``
-        + `import http from 'http';\n`
-        + `import https from 'https';\n`
-        + `import nodeFetch from 'node-fetch';\n`
-        + `import FormData from 'form-data';\n\n`
-        + `const options = { keepAlive: true };\n`
-        + `const httpAgent = new http.Agent(options);\n`
-        + `const httpsAgent = new https.Agent(options);\n`
-        + `const agent = (url) => url.protocol === 'http:' ? httpAgent : httpsAgent;\n`
-        + `const fetch = (url, init) => nodeFetch(url, { agent, ...init });\n`,
-    },
-  ],
-  plugins: [
-    typescript({ tsconfig: './tsconfig.json' }),
-    terser()
-  ],
-};
+    plugins: [
+      dts.default(),
+      {
+        generateBundle(_, bundle) {
+          for (const file of Object.values(bundle)) {
+            file.code = file.code.replace(/declare const ([\w$]+): typeof (\w+);/g, 'type $1 = $2;');
+          }
+        }
+      }
+    ],
+  },
+  {
+    input: 'src/TestRail.ts',
+    external: [],
+    output: [
+      {
+        file: pkg.browser,
+        format: 'es',
+        exports: 'default',
+        sourcemap: true,
+      },
+      {
+        file: pkg.jsdelivr,
+        format: 'umd',
+        exports: 'default',
+        sourcemap: true,
+        name: 'TestRail',
+      },
+      {
+        file: pkg.main,
+        format: 'cjs',
+        exports: 'default',
+        strict: false,
+        sourcemap: true,
+        banner: `'use strict';\n`
+          + `const http = require('http');\n`
+          + `const https = require('https');\n`
+          + `const nodeFetch = require('node-fetch');\n`
+          + `const FormData = require('form-data');\n\n`
+          + `const options = { keepAlive: true };\n`
+          + `const httpAgent = new http.Agent(options);\n`
+          + `const httpsAgent = new https.Agent(options);\n`
+          + `const agent = (url) => url.protocol === 'http:' ? httpAgent : httpsAgent;\n`
+          + `const fetch = (url, init) => nodeFetch(url, { agent, ...init });\n`,
+      },
+      {
+        file: pkg.module,
+        format: 'es',
+        exports: 'default',
+        sourcemap: true,
+        banner: ``
+          + `import http from 'http';\n`
+          + `import https from 'https';\n`
+          + `import nodeFetch from 'node-fetch';\n`
+          + `import FormData from 'form-data';\n\n`
+          + `const options = { keepAlive: true };\n`
+          + `const httpAgent = new http.Agent(options);\n`
+          + `const httpsAgent = new https.Agent(options);\n`
+          + `const agent = (url) => url.protocol === 'http:' ? httpAgent : httpsAgent;\n`
+          + `const fetch = (url, init) => nodeFetch(url, { agent, ...init });\n`,
+      },
+    ],
+    plugins: [
+      typescript({ tsconfig: './tsconfig.json' }),
+      terser()
+    ],
+  }
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ export default [
     external: ['stream'],
     output: {
       file: 'dist/TestRail.d.ts',
-      format: 'cjs',
+      format: 'es',
       footer: '\n// @ts-ignore\nexport = TestRail;',
     },
     plugins: [

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,0 @@
-export * from './TestRail';
-
-import TestRail from './TestRail';
-
-// @ts-ignore
-export = TestRail;

--- a/test/bdd.ts
+++ b/test/bdd.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import type { AddAttachment, Case } from '../src/types';
+import type { AddAttachment, Case } from '..';
 import { OK, api, jsonFor, on } from './_helper';
 
 describe('BDD', () => {


### PR DESCRIPTION
Ship type definition as `.d.ts` instead of `.ts` which make `skipLibCheck` option from tsconfig works (fix #73) and updated source-map to point to correct source file.