### PR TITLE
fix: TestRail 9.3.1 support

### DIFF
--- a/src/groups/suites.ts
+++ b/src/groups/suites.ts
@@ -1,13 +1,16 @@
 import type { TestRailCtx } from '../TestRailCtx';
+import { pagination } from '../internal/pagination';
 import { _api } from '../internal/request';
-import type { AddSuite, Suite, UpdateSuite } from '../payload';
+import type { AddSuite, Pagination, Suite, UpdateSuite } from '../payload';
 
 export function getSuite(ctx: TestRailCtx, suiteId: number): Promise<Suite> {
   return _api(ctx, 'GET', `get_suite/${suiteId}`);
 }
 
-export function getSuites(ctx: TestRailCtx, projectId: number): Promise<Suite[]> {
-  return _api(ctx, 'GET', `get_suites/${projectId}`);
+export function getSuites(ctx: TestRailCtx, projectId: number, filters?: Pagination): Promise<Suite[]> {
+  return pagination('suites', filters, (filters) => {
+    return _api(ctx, 'GET', `get_suites/${projectId}`, { query: filters });
+  });
 }
 
 export function addSuite(ctx: TestRailCtx, projectId: number, payload: AddSuite): Promise<Suite> {

--- a/src/groups/users.ts
+++ b/src/groups/users.ts
@@ -1,4 +1,5 @@
 import type { TestRailCtx } from '../TestRailCtx';
+import { pagination } from '../internal/pagination';
 import { _api } from '../internal/request';
 import type { AddUser, User, UserFilters } from '../payload';
 
@@ -15,7 +16,9 @@ export function getUserByEmail(ctx: TestRailCtx, email: string): Promise<User> {
 }
 
 export function getUsers(ctx: TestRailCtx, filters?: UserFilters): Promise<User[]> {
-  return _api(ctx, 'GET', 'get_users', { query: filters });
+  return pagination('users', filters, (filters) => {
+    return _api(ctx, 'GET', 'get_users', { query: filters });
+  });
 }
 
 export function addUser(ctx: TestRailCtx, payload: AddUser): Promise<User> {

--- a/src/payload/request/UserFilters.ts
+++ b/src/payload/request/UserFilters.ts
@@ -1,3 +1,5 @@
-export interface UserFilters extends Record<string, unknown> {
+import type { Pagination } from "./Pagination";
+
+export interface UserFilters extends Pagination, Record<string, unknown> {
   project_id?: number;
 }

--- a/test/suites.ts
+++ b/test/suites.ts
@@ -20,7 +20,7 @@ describe('Suites', () => {
   });
 
   it('get suites', async () => {
-    on(`get_suites/${projectId}`)
+    on(`get_suites/${projectId}&limit=250&offset=0`)
       .reply(OK, suites);
 
     await api

--- a/test/users.ts
+++ b/test/users.ts
@@ -38,7 +38,7 @@ describe('Users', () => {
   });
 
   it('get users', async () => {
-    on('get_users')
+    on('get_users&limit=250&offset=0')
       .reply(OK, users);
 
     await api
@@ -47,7 +47,7 @@ describe('Users', () => {
   });
 
   it('get filtered users', async () => {
-    on(`get_users&${qs(userFilters)}`)
+    on(`get_users&${qs(userFilters)}&limit=250&offset=0`)
       .reply(OK, users);
 
     await api


### PR DESCRIPTION
Closes: #76

Update client for [TestRail 9.3.1](https://support.testrail.com/hc/en-us/articles/39188927555092-TestRail-9-3-1-Default-1020) compatibility.

* Handle pagination for `get_suites`
* Handle pagination for `get_users` (undocumented)
