### PR TITLE
chore: release 1.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlenroc/testrail",
   "description": "TestRail API client with error handling and typing",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "author": "Corneliu Duplachi",
   "license": "MIT",
   "homepage": "https://github.com/dlenroc/node-testrail-api",


### PR DESCRIPTION
Republish the latest npm package versions with a patch increment to allow continued use while the original versions are being restored. Restoration may take additional time due to technical issues on the npm registry.